### PR TITLE
feat: provider-boundary v1 with shared tool interception

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,21 @@ No prompt limits. No broken streams. Full thinking + tool support in Opencode. Y
 curl -fsSL https://raw.githubusercontent.com/Nomadcxx/opencode-cursor/main/install.sh | bash
 ```
 
-**Option B: TUI Installer**
+**Option B: npm Package (Recommended for updates)**
+
+```bash
+npm install -g open-cursor
+open-cursor install
+```
+
+Upgrade later with:
+
+```bash
+npm update -g open-cursor
+open-cursor sync-models
+```
+
+**Option C: TUI Installer**
 
 ```bash
 git clone https://github.com/Nomadcxx/opencode-cursor.git
@@ -23,7 +37,7 @@ cd opencode-cursor
 go build -o ./installer ./cmd/installer && ./installer
 ```
 
-**Option C: Let an LLM do it**
+**Option D: Let an LLM do it**
 
 Paste this into any LLM agent (Claude Code, OpenCode, Cursor, etc.):
 
@@ -51,7 +65,7 @@ Install the cursor-acp plugin for OpenCode:
 5. Verify: opencode models | grep cursor
 ```
 
-**Option D: Manual Install**
+**Option E: Manual Install**
 
 ```bash
 bun install && bun run build
@@ -140,6 +154,13 @@ Credential file locations:
 ```bash
 opencode run "your prompt" --model cursor-acp/auto
 opencode run "your prompt" --model cursor-acp/sonnet-4.5
+```
+
+If installed via npm, manage setup with:
+
+```bash
+open-cursor status
+open-cursor sync-models
 ```
 
 ## Models
@@ -272,6 +293,7 @@ CI runs split suites in `.github/workflows/ci.yml`:
 Integration CI defaults to OpenCode-owned loop mode:
 
 - `CURSOR_ACP_TOOL_LOOP_MODE=opencode`
+- `CURSOR_ACP_PROVIDER_BOUNDARY=v1`
 - `CURSOR_ACP_ENABLE_OPENCODE_TOOLS=true`
 - `CURSOR_ACP_FORWARD_TOOL_CALLS=false`
 - `CURSOR_ACP_EMIT_TOOL_UPDATES=false`
@@ -301,6 +323,10 @@ Set the log level via environment variable:
 - `CURSOR_ACP_LOG_LEVEL=info` - Default level
 - `CURSOR_ACP_LOG_LEVEL=warn` - Warnings and errors only
 - `CURSOR_ACP_LOG_LEVEL=error` - Errors only
+
+Provider-boundary rollout:
+- `CURSOR_ACP_PROVIDER_BOUNDARY=legacy` - Original provider/runtime boundary behavior
+- `CURSOR_ACP_PROVIDER_BOUNDARY=v1` - New shared boundary/interception path (recommended)
 
 Disable log output entirely:
 ```bash

--- a/src/provider/boundary.ts
+++ b/src/provider/boundary.ts
@@ -1,0 +1,161 @@
+import type { OpenAiToolCall, ToolLoopMeta } from "../proxy/tool-loop.js";
+import {
+  createToolCallCompletionResponse,
+  createToolCallStreamChunks,
+  extractOpenAiToolCall,
+} from "../proxy/tool-loop.js";
+import type { StreamJsonToolCallEvent } from "../streaming/types.js";
+
+export type ToolLoopMode = "opencode" | "proxy-exec" | "off";
+
+export type ProviderBoundaryMode = "legacy" | "v1";
+
+export type ToolOptionResolution = {
+  tools: unknown;
+  action: "preserve" | "fallback" | "override" | "none";
+};
+
+export interface ToolLoopFlags {
+  proxyExecuteToolCalls: boolean;
+  suppressConverterToolEvents: boolean;
+  shouldEmitToolUpdates: boolean;
+}
+
+export interface ProviderBoundary {
+  readonly mode: ProviderBoundaryMode;
+  readonly providerId: string;
+  resolveChatParamTools(
+    toolLoopMode: ToolLoopMode,
+    existingTools: unknown,
+    refreshedTools: Array<any>,
+  ): ToolOptionResolution;
+  computeToolLoopFlags(
+    toolLoopMode: ToolLoopMode,
+    forwardToolCalls: boolean,
+    emitToolUpdates: boolean,
+  ): ToolLoopFlags;
+  matchesProvider(inputModel: any): boolean;
+  normalizeRuntimeModel(model: unknown): string;
+  applyChatParamDefaults(
+    output: any,
+    proxyBaseURL: string | undefined,
+    defaultBaseURL: string,
+    defaultApiKey: string,
+  ): void;
+  maybeExtractToolCall(
+    event: StreamJsonToolCallEvent,
+    allowedToolNames: Set<string>,
+    toolLoopMode: ToolLoopMode,
+  ): OpenAiToolCall | null;
+  createNonStreamToolCallResponse(meta: ToolLoopMeta, toolCall: OpenAiToolCall): any;
+  createStreamToolCallChunks(meta: ToolLoopMeta, toolCall: OpenAiToolCall): Array<any>;
+}
+
+export function parseProviderBoundaryMode(
+  value: string | undefined,
+): { mode: ProviderBoundaryMode; valid: boolean } {
+  const normalized = (value ?? "legacy").trim().toLowerCase();
+  if (normalized === "legacy" || normalized === "v1") {
+    return { mode: normalized, valid: true };
+  }
+  return { mode: "legacy", valid: false };
+}
+
+export function createProviderBoundary(
+  mode: ProviderBoundaryMode,
+  providerId: string,
+): ProviderBoundary {
+  const shared = createSharedBoundary(providerId);
+  if (mode === "v1") {
+    return { ...shared, mode: "v1" };
+  }
+  return { ...shared, mode: "legacy" };
+}
+
+function createSharedBoundary(
+  providerId: string,
+): Omit<ProviderBoundary, "mode"> {
+  return {
+    providerId,
+
+    resolveChatParamTools(toolLoopMode, existingTools, refreshedTools) {
+      if (toolLoopMode === "proxy-exec") {
+        if (refreshedTools.length > 0) {
+          return { tools: refreshedTools, action: "override" };
+        }
+        return { tools: existingTools, action: "none" };
+      }
+
+      if (toolLoopMode === "opencode") {
+        if (existingTools != null) {
+          return { tools: existingTools, action: "preserve" };
+        }
+        if (refreshedTools.length > 0) {
+          return { tools: refreshedTools, action: "fallback" };
+        }
+        return { tools: existingTools, action: "none" };
+      }
+
+      return { tools: existingTools, action: "none" };
+    },
+
+    computeToolLoopFlags(toolLoopMode, forwardToolCalls, emitToolUpdates) {
+      const proxyExec = toolLoopMode === "proxy-exec";
+      return {
+        proxyExecuteToolCalls: proxyExec && forwardToolCalls,
+        suppressConverterToolEvents: proxyExec && !forwardToolCalls,
+        shouldEmitToolUpdates: proxyExec && emitToolUpdates,
+      };
+    },
+
+    matchesProvider(inputModel: any) {
+      if (!inputModel || typeof inputModel !== "object") {
+        return false;
+      }
+
+      const modelProviderId =
+        (typeof inputModel.providerID === "string" && inputModel.providerID)
+        || (typeof inputModel.providerId === "string" && inputModel.providerId)
+        || (typeof inputModel.provider === "string" && inputModel.provider)
+        || "";
+
+      return modelProviderId === providerId;
+    },
+
+    normalizeRuntimeModel(model) {
+      const raw = typeof model === "string" ? model.trim() : "";
+      if (raw.length === 0) {
+        return "auto";
+      }
+
+      const prefix = `${providerId}/`;
+      if (raw.startsWith(prefix)) {
+        const stripped = raw.slice(prefix.length).trim();
+        return stripped.length > 0 ? stripped : "auto";
+      }
+
+      return raw;
+    },
+
+    applyChatParamDefaults(output, proxyBaseURL, defaultBaseURL, defaultApiKey) {
+      output.options = output.options || {};
+      output.options.baseURL = proxyBaseURL || defaultBaseURL;
+      output.options.apiKey = output.options.apiKey || defaultApiKey;
+    },
+
+    maybeExtractToolCall(event, allowedToolNames, toolLoopMode) {
+      if (toolLoopMode !== "opencode") {
+        return null;
+      }
+      return extractOpenAiToolCall(event, allowedToolNames);
+    },
+
+    createNonStreamToolCallResponse(meta, toolCall) {
+      return createToolCallCompletionResponse(meta, toolCall);
+    },
+
+    createStreamToolCallChunks(meta, toolCall) {
+      return createToolCallStreamChunks(meta, toolCall);
+    },
+  };
+}

--- a/src/provider/runtime-interception.ts
+++ b/src/provider/runtime-interception.ts
@@ -1,0 +1,82 @@
+import type { ToolUpdate, ToolMapper } from "../acp/tools.js";
+import type { OpenAiToolCall } from "../proxy/tool-loop.js";
+import type { StreamJsonToolCallEvent } from "../streaming/types.js";
+import type { ToolRouter } from "../tools/router.js";
+import type { ToolLoopMode } from "./boundary.js";
+import type { ProviderBoundary } from "./boundary.js";
+
+export interface HandleToolLoopEventOptions {
+  event: StreamJsonToolCallEvent;
+  boundary: ProviderBoundary;
+  toolLoopMode: ToolLoopMode;
+  allowedToolNames: Set<string>;
+  toolMapper: ToolMapper;
+  toolSessionId: string;
+  shouldEmitToolUpdates: boolean;
+  proxyExecuteToolCalls: boolean;
+  suppressConverterToolEvents: boolean;
+  toolRouter?: ToolRouter;
+  responseMeta: { id: string; created: number; model: string };
+  onToolUpdate: (update: ToolUpdate) => Promise<void> | void;
+  onToolResult: (toolResult: any) => Promise<void> | void;
+  onInterceptedToolCall: (toolCall: OpenAiToolCall) => Promise<void> | void;
+}
+
+export interface HandleToolLoopEventResult {
+  intercepted: boolean;
+  skipConverter: boolean;
+}
+
+export async function handleToolLoopEvent(
+  options: HandleToolLoopEventOptions,
+): Promise<HandleToolLoopEventResult> {
+  const {
+    event,
+    boundary,
+    toolLoopMode,
+    allowedToolNames,
+    toolMapper,
+    toolSessionId,
+    shouldEmitToolUpdates,
+    proxyExecuteToolCalls,
+    suppressConverterToolEvents,
+    toolRouter,
+    responseMeta,
+    onToolUpdate,
+    onToolResult,
+    onInterceptedToolCall,
+  } = options;
+
+  const updates = await toolMapper.mapCursorEventToAcp(
+    event,
+    event.session_id ?? toolSessionId,
+  );
+
+  if (shouldEmitToolUpdates) {
+    for (const update of updates) {
+      await onToolUpdate(update);
+    }
+  }
+
+  const interceptedToolCall = boundary.maybeExtractToolCall(
+    event,
+    allowedToolNames,
+    toolLoopMode,
+  );
+  if (interceptedToolCall) {
+    await onInterceptedToolCall(interceptedToolCall);
+    return { intercepted: true, skipConverter: true };
+  }
+
+  if (toolRouter && proxyExecuteToolCalls) {
+    const toolResult = await toolRouter.handleToolCall(event as any, responseMeta);
+    if (toolResult) {
+      await onToolResult(toolResult);
+    }
+  }
+
+  return {
+    intercepted: false,
+    skipConverter: suppressConverterToolEvents,
+  };
+}

--- a/tests/unit/provider-boundary.test.ts
+++ b/tests/unit/provider-boundary.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createProviderBoundary,
+  parseProviderBoundaryMode,
+  type ToolLoopMode,
+} from "../../src/provider/boundary";
+
+describe("provider boundary", () => {
+  it("parses provider boundary mode with legacy default", () => {
+    expect(parseProviderBoundaryMode("legacy")).toEqual({ mode: "legacy", valid: true });
+    expect(parseProviderBoundaryMode("v1")).toEqual({ mode: "v1", valid: true });
+    expect(parseProviderBoundaryMode(undefined)).toEqual({ mode: "legacy", valid: true });
+    expect(parseProviderBoundaryMode("invalid")).toEqual({ mode: "legacy", valid: false });
+  });
+
+  it("keeps legacy and v1 resolveChatParamTools behavior identical", () => {
+    const legacy = createProviderBoundary("legacy", "cursor-acp");
+    const v1 = createProviderBoundary("v1", "cursor-acp");
+
+    const cases: Array<{
+      mode: ToolLoopMode;
+      existing: unknown;
+      refreshed: Array<any>;
+    }> = [
+      { mode: "opencode", existing: [{ function: { name: "external" } }], refreshed: [] },
+      { mode: "opencode", existing: undefined, refreshed: [{ function: { name: "oc_bash" } }] },
+      { mode: "proxy-exec", existing: [{ function: { name: "legacy" } }], refreshed: [{ function: { name: "new" } }] },
+      { mode: "off", existing: [{ function: { name: "keep" } }], refreshed: [{ function: { name: "ignored" } }] },
+      { mode: "proxy-exec", existing: undefined, refreshed: [] },
+    ];
+
+    for (const testCase of cases) {
+      const lhs = legacy.resolveChatParamTools(testCase.mode, testCase.existing, testCase.refreshed);
+      const rhs = v1.resolveChatParamTools(testCase.mode, testCase.existing, testCase.refreshed);
+      expect(lhs).toEqual(rhs);
+    }
+  });
+
+  it("computes loop flags based on tool loop mode and env toggles", () => {
+    const boundary = createProviderBoundary("v1", "cursor-acp");
+
+    expect(boundary.computeToolLoopFlags("opencode", true, true)).toEqual({
+      proxyExecuteToolCalls: false,
+      suppressConverterToolEvents: false,
+      shouldEmitToolUpdates: false,
+    });
+
+    expect(boundary.computeToolLoopFlags("proxy-exec", true, false)).toEqual({
+      proxyExecuteToolCalls: true,
+      suppressConverterToolEvents: false,
+      shouldEmitToolUpdates: false,
+    });
+
+    expect(boundary.computeToolLoopFlags("proxy-exec", false, true)).toEqual({
+      proxyExecuteToolCalls: false,
+      suppressConverterToolEvents: true,
+      shouldEmitToolUpdates: true,
+    });
+  });
+
+  it("normalizes provider-prefixed model names", () => {
+    const boundary = createProviderBoundary("v1", "cursor-acp");
+    expect(boundary.normalizeRuntimeModel("cursor-acp/auto")).toBe("auto");
+    expect(boundary.normalizeRuntimeModel("cursor-acp/gpt-5.3-codex")).toBe("gpt-5.3-codex");
+    expect(boundary.normalizeRuntimeModel("auto")).toBe("auto");
+    expect(boundary.normalizeRuntimeModel(undefined)).toBe("auto");
+    expect(boundary.normalizeRuntimeModel("   ")).toBe("auto");
+  });
+
+  it("matches provider across providerID/providerId/provider keys", () => {
+    const boundary = createProviderBoundary("v1", "cursor-acp");
+    expect(boundary.matchesProvider({ providerID: "cursor-acp" })).toBe(true);
+    expect(boundary.matchesProvider({ providerId: "cursor-acp" })).toBe(true);
+    expect(boundary.matchesProvider({ provider: "cursor-acp" })).toBe(true);
+    expect(boundary.matchesProvider({ providerID: "other" })).toBe(false);
+    expect(boundary.matchesProvider(undefined)).toBe(false);
+  });
+
+  it("applies chat param defaults without clobbering existing api key", () => {
+    const boundary = createProviderBoundary("v1", "cursor-acp");
+    const output: any = { options: { apiKey: "existing-key" } };
+    boundary.applyChatParamDefaults(output, "http://127.0.0.1:32124/v1", "http://fallback/v1", "cursor-agent");
+    expect(output.options.baseURL).toBe("http://127.0.0.1:32124/v1");
+    expect(output.options.apiKey).toBe("existing-key");
+  });
+
+  it("extracts tool calls only for opencode mode and returns formatted responses", () => {
+    const boundary = createProviderBoundary("v1", "cursor-acp");
+    const event: any = {
+      type: "tool_call",
+      call_id: "c1",
+      name: "updateTodos",
+      tool_call: {
+        updateTodos: {
+          args: { todos: [{ content: "Book flights", status: "pending" }] },
+        },
+      },
+    };
+
+    const call = boundary.maybeExtractToolCall(event, new Set(["todowrite"]), "opencode");
+    expect(call?.function.name).toBe("todowrite");
+
+    const skipped = boundary.maybeExtractToolCall(event, new Set(["todowrite"]), "proxy-exec");
+    expect(skipped).toBeNull();
+
+    const meta = { id: "resp-1", created: 123, model: "auto" };
+    const nonStream = boundary.createNonStreamToolCallResponse(meta, call!);
+    expect(nonStream.choices[0].finish_reason).toBe("tool_calls");
+
+    const stream = boundary.createStreamToolCallChunks(meta, call!);
+    expect(stream).toHaveLength(2);
+    expect(stream[1].choices[0].finish_reason).toBe("tool_calls");
+  });
+});


### PR DESCRIPTION
## Summary
- add a provider-boundary abstraction with legacy/v1 mode selection via CURSOR_ACP_PROVIDER_BOUNDARY
- wire plugin chat/provider/tool-loop decisions through boundary helpers (tool option resolution, provider matching, model normalization, defaults)
- extract shared runtime tool_call handling to remove duplicated interception/update/result logic across Bun and Node streaming paths
- keep rollback safety by preserving legacy mode and parity behavior while enabling v1 rollout
- add boundary-focused unit tests and integration coverage for provider-prefixed model normalization (cursor-acp/<model>)
- document boundary rollout env var in README

## Key Files
- src/provider/boundary.ts
- src/provider/runtime-interception.ts
- src/plugin.ts
- tests/unit/provider-boundary.test.ts
- tests/integration/opencode-loop.integration.test.ts
- README.md

## Validation
- bun run test:ci:unit
- bun run test:ci:integration

Both suites pass locally in this environment.
