### PR TITLE
fix: port targeted plugin-disable and BSD grep fixes from #20

### DIFF
--- a/src/plugin-entry.ts
+++ b/src/plugin-entry.ts
@@ -1,8 +1,28 @@
 /**
- * Minimal entrypoint for the OpenCode plugin loader.
- * Exports only the CursorPlugin to avoid non-plugin exports being
- * treated as plugins by OpenCode.
+ * OpenCode-only entrypoint.
+ *
+ * When cursor-acp is removed from the `plugin` array in opencode.json,
+ * this entrypoint turns into a no-op so users can disable the plugin
+ * without deleting the symlink file.
  */
-import { CursorPlugin } from "./plugin.js";
+import type { Plugin } from "@opencode-ai/plugin";
+import { shouldEnableCursorPlugin } from "./plugin-toggle.js";
+import { createLogger } from "./utils/logger.js";
 
-export default CursorPlugin;
+const log = createLogger("plugin-entry");
+
+const CursorPluginEntry: Plugin = async (input) => {
+  const state = shouldEnableCursorPlugin();
+  if (!state.enabled) {
+    log.info("Plugin disabled in OpenCode config; skipping initialization", {
+      configPath: state.configPath,
+      reason: state.reason,
+    });
+    return {};
+  }
+
+  const mod = await import("./plugin.js");
+  return mod.CursorPlugin(input);
+};
+
+export default CursorPluginEntry;

--- a/src/plugin-toggle.ts
+++ b/src/plugin-toggle.ts
@@ -1,0 +1,67 @@
+import { existsSync, readFileSync } from "fs";
+import { homedir } from "os";
+import { join, resolve } from "path";
+
+const CURSOR_PROVIDER_ID = "cursor-acp";
+
+type EnvLike = Record<string, string | undefined>;
+
+export function resolveOpenCodeConfigPath(env: EnvLike = process.env): string {
+  if (env.OPENCODE_CONFIG && env.OPENCODE_CONFIG.length > 0) {
+    return resolve(env.OPENCODE_CONFIG);
+  }
+
+  const configHome = env.XDG_CONFIG_HOME && env.XDG_CONFIG_HOME.length > 0
+    ? env.XDG_CONFIG_HOME
+    : join(homedir(), ".config");
+
+  return join(configHome, "opencode", "opencode.json");
+}
+
+export function isCursorPluginEnabledInConfig(config: unknown): boolean {
+  if (!config || typeof config !== "object") {
+    return true;
+  }
+
+  const configObject = config as { plugin?: unknown; provider?: unknown };
+
+  if (Array.isArray(configObject.plugin)) {
+    return configObject.plugin.some((entry) => entry === CURSOR_PROVIDER_ID);
+  }
+
+  return true;
+}
+
+export function shouldEnableCursorPlugin(env: EnvLike = process.env): {
+  enabled: boolean;
+  configPath: string;
+  reason: string;
+} {
+  const configPath = resolveOpenCodeConfigPath(env);
+
+  if (!existsSync(configPath)) {
+    return {
+      enabled: true,
+      configPath,
+      reason: "config_missing",
+    };
+  }
+
+  try {
+    const raw = readFileSync(configPath, "utf8");
+    const parsed = JSON.parse(raw);
+    const enabled = isCursorPluginEnabledInConfig(parsed);
+
+    return {
+      enabled,
+      configPath,
+      reason: enabled ? "enabled_in_plugin_array_or_legacy" : "disabled_in_plugin_array",
+    };
+  } catch {
+    return {
+      enabled: true,
+      configPath,
+      reason: "config_unreadable_or_invalid",
+    };
+  }
+}

--- a/tests/tools/defaults.test.ts
+++ b/tests/tools/defaults.test.ts
@@ -75,14 +75,17 @@ describe("Default Tools", () => {
     const registry = new ToolRegistry();
     registerDefaultTools(registry);
     const executor = new LocalExecutor(registry);
+    const fs = await import("fs");
+    const os = await import("os");
+    const workdir = os.tmpdir();
 
     const result = await executeWithChain([executor], "bash", {
       cmd: "pwd",
-      workdir: "/tmp",
+      workdir,
     });
 
     expect(result.status).toBe("success");
-    expect(result.output?.trim()).toBe("/tmp");
+    expect(fs.realpathSync(result.output?.trim() ?? "")).toBe(fs.realpathSync(workdir));
   });
 
   it("should execute read tool", async () => {
@@ -244,6 +247,28 @@ describe("Default Tools", () => {
 
     expect(result.status).toBe("success");
     expect(result.output).toContain("hello world");
+
+    fs.unlinkSync(tmpFile);
+  });
+
+  it("should retry grep with extended regex when BSD basic regex rejects pattern", async () => {
+    const registry = new ToolRegistry();
+    registerDefaultTools(registry);
+    const executor = new LocalExecutor(registry);
+
+    const fs = await import("fs");
+    const os = await import("os");
+    const path = await import("path");
+    const tmpFile = path.join(os.tmpdir(), `test-grep-bsd-${Date.now()}.txt`);
+    fs.writeFileSync(tmpFile, "export DEFAULT=${MY_VAR:-fallback}\n", "utf-8");
+
+    const result = await executeWithChain([executor], "grep", {
+      pattern: "\\$\\{[A-Z_][A-Z0-9_]*:-",
+      path: tmpFile,
+    });
+
+    expect(result.status).toBe("success");
+    expect(result.output).toContain("DEFAULT=${MY_VAR:-fallback}");
 
     fs.unlinkSync(tmpFile);
   });

--- a/tests/unit/plugin-toggle.test.ts
+++ b/tests/unit/plugin-toggle.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="bun-types/test-globals" />
+
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  isCursorPluginEnabledInConfig,
+  resolveOpenCodeConfigPath,
+  shouldEnableCursorPlugin,
+} from "../../src/plugin-toggle";
+
+describe("plugin toggle", () => {
+  it("enables plugin when plugin array includes cursor-acp", () => {
+    expect(isCursorPluginEnabledInConfig({ plugin: ["cursor-acp"] })).toBe(true);
+  });
+
+  it("disables plugin when plugin array excludes cursor-acp", () => {
+    expect(isCursorPluginEnabledInConfig({ plugin: ["other-plugin"] })).toBe(false);
+  });
+
+  it("keeps legacy behavior when plugin array is missing", () => {
+    expect(isCursorPluginEnabledInConfig({ provider: { "cursor-acp": {} } })).toBe(true);
+    expect(isCursorPluginEnabledInConfig({ provider: {} })).toBe(true);
+  });
+
+  it("resolves config from OPENCODE_CONFIG first", () => {
+    const customConfig = join(tmpdir(), "custom-opencode.json");
+    const xdgHome = join(tmpdir(), "xdg");
+    const path = resolveOpenCodeConfigPath({
+      OPENCODE_CONFIG: customConfig,
+      XDG_CONFIG_HOME: xdgHome,
+    });
+    expect(path).toBe(customConfig);
+  });
+
+  it("disables when config file exists and plugin array excludes cursor-acp", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cursor-toggle-"));
+    const configPath = join(dir, "opencode.json");
+
+    try {
+      writeFileSync(configPath, JSON.stringify({ plugin: ["other-plugin"] }));
+      const state = shouldEnableCursorPlugin({ OPENCODE_CONFIG: configPath });
+      expect(state.enabled).toBe(false);
+      expect(state.reason).toBe("disabled_in_plugin_array");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("stays enabled when config is invalid JSON", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cursor-toggle-"));
+    const configPath = join(dir, "opencode.json");
+
+    try {
+      writeFileSync(configPath, "{not-json");
+      const state = shouldEnableCursorPlugin({ OPENCODE_CONFIG: configPath });
+      expect(state.enabled).toBe(true);
+      expect(state.reason).toBe("config_unreadable_or_invalid");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
This PR ports the two still-relevant fixes from #20 into a clean branch based on current `main`:

1. Plugin-entry disable guard
- adds config-aware plugin toggle so entrypoint no-ops when `cursor-acp` is removed from the `plugin` array in `opencode.json`
- supports `OPENCODE_CONFIG`, `XDG_CONFIG_HOME`, and default config path resolution

2. BSD/macOS grep regex fallback
- retries `grep` with `-E` on code=2 regex syntax errors (e.g. `Unmatched {`, invalid repetition)
- preserves existing no-match behavior (`code=1 => No matches found`)

## Why new PR instead of merging #20
#20 became a stacked umbrella branch and now conflicts with current `main` after multiple merges (#22, #23, and later tool-loop changes).
This PR isolates only the missing pieces to avoid regressing newer architecture work.

## Attribution
Extracted from work by @hawkff in #20.
Original commits referenced in commit message:
- cd39ea8068ec47ce6ada1961ca0cb069e7074590
- aa97a1a0b9cbf017c80b657445ad5d9c987e22d0

## Validation
- `bun test tests/unit/plugin-toggle.test.ts tests/tools/defaults.test.ts tests/unit/plugin-tools-hook.test.ts`
- `bun run build`
