### PR TITLE
feat(cli): enhance Node CLI with branding, doctor command, and JSON status

### DIFF
--- a/tests/unit/cli/opencode-cursor.test.ts
+++ b/tests/unit/cli/opencode-cursor.test.ts
@@ -6,6 +6,7 @@ import {
   checkCursorAgent,
   checkCursorAgentLogin,
   runDoctorChecks,
+  getStatusResult,
 } from "../../../src/cli/opencode-cursor.js";
 
 describe("cli/opencode-cursor branding", () => {
@@ -46,5 +47,14 @@ describe("cli/opencode-cursor commandDoctor", () => {
     const results = runDoctorChecks("/tmp/test-config.json", "/tmp/test-plugin");
     expect(results.length).toBeGreaterThan(5);
     expect(results.every(r => typeof r.passed === "boolean")).toBe(true);
+  });
+});
+
+describe("cli/opencode-cursor status", () => {
+  it("getStatusResult returns structured data", () => {
+    const result = getStatusResult("/tmp/test-config.json", "/tmp/test-plugin");
+    expect(result).toHaveProperty("plugin");
+    expect(result).toHaveProperty("provider");
+    expect(result).toHaveProperty("aiSdk");
   });
 });


### PR DESCRIPTION
## Summary

- Add ASCII branding header to help output with stylized "open-cursor" logo
- Add `doctor` command to diagnose common issues (bun, cursor-agent, login, OpenCode, plugin, config, AI SDK)
- Enhance `status` command with structured output and `--json` flag for machine-readable format

## Commands Available

```
open-cursor install     Configure OpenCode for Cursor (idempotent, safe to re-run)
open-cursor sync-models Refresh model list from cursor-agent
open-cursor status      Show current configuration state
open-cursor doctor      Diagnose common issues
open-cursor uninstall   Remove cursor-acp from OpenCode config
open-cursor help        Show this help message
```

## Test Plan

- [x] `open-cursor help` shows ASCII branding and command list
- [x] `open-cursor status` shows human-readable plugin/provider/AI SDK status
- [x] `open-cursor status --json` outputs valid JSON
- [x] `open-cursor doctor` runs all 7 diagnostic checks with colored output
- [x] All 8 unit tests pass