### PR TITLE
fix: Add proxy health reuse guard, await child.exited for SSE stream

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -152,6 +152,26 @@ function resolveWorkspaceDirectory(worktree: string | undefined, directory: stri
   return dirCandidate || cwd || configPrefix;
 }
 
+type ProxyRuntimeState = {
+  baseURL?: string;
+  baseURLByWorkspace?: Record<string, string>;
+};
+
+export function normalizeWorkspaceForCompare(pathValue: string): string {
+  return resolve(pathValue);
+}
+
+export function isReusableProxyHealthPayload(payload: any, workspaceDirectory: string): boolean {
+  if (!payload || payload.ok !== true) {
+    return false;
+  }
+  if (typeof payload.workspaceDirectory !== "string" || payload.workspaceDirectory.length === 0) {
+    // Legacy proxies that do not expose workspace cannot be safely reused.
+    return false;
+  }
+  return normalizeWorkspaceForCompare(payload.workspaceDirectory) === normalizeWorkspaceForCompare(workspaceDirectory);
+}
+
 const FORCE_TOOL_MODE = process.env.CURSOR_ACP_FORCE !== "false";
 const EMIT_TOOL_UPDATES = process.env.CURSOR_ACP_EMIT_TOOL_UPDATES === "true";
 const FORWARD_TOOL_CALLS = process.env.CURSOR_ACP_FORWARD_TOOL_CALLS !== "false";
@@ -422,21 +442,25 @@ async function findFirstAllowedToolCallInOutput(
 async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: ToolRouter): Promise<string> {
   const key = getGlobalKey();
   const g = globalThis as any;
+  const normalizedWorkspace = normalizeWorkspaceForCompare(workspaceDirectory);
+  const state: ProxyRuntimeState = g[key] ?? { baseURL: "", baseURLByWorkspace: {} };
+  state.baseURLByWorkspace = state.baseURLByWorkspace ?? {};
+  g[key] = state;
 
-  const existingBaseURL = g[key]?.baseURL;
+  const existingBaseURL = state.baseURLByWorkspace[normalizedWorkspace] ?? state.baseURL;
   if (typeof existingBaseURL === "string" && existingBaseURL.length > 0) {
     return existingBaseURL;
   }
 
   // Mark as starting to avoid duplicate starts in-process.
-  g[key] = { baseURL: "" };
+  state.baseURL = "";
 
       const handler = async (req: Request): Promise<Response> => {
         try {
           const url = new URL(req.url);
 
       if (url.pathname === "/health") {
-        return new Response(JSON.stringify({ ok: true }), {
+        return new Response(JSON.stringify({ ok: true, workspaceDirectory }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });
@@ -560,7 +584,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
         const stdout = (stdoutText || "").trim();
         const stderr = (stderrText || "").trim();
-        const exitCode = child.exitCode;
+        const exitCode = await child.exited;
         log.debug("cursor-agent completed (bun non-stream)", {
           exitCode,
           stdoutChars: stdout.length,
@@ -808,15 +832,16 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
               return;
             }
 
-            if (child.exitCode !== 0) {
+            const exitCode = await child.exited;
+            if (exitCode !== 0) {
               const stderrText = await new Response(child.stderr).text();
               const errSource = (stderrText || "").trim()
-                || `cursor-agent exited with code ${String(child.exitCode ?? "unknown")} and no output`;
+                || `cursor-agent exited with code ${String(exitCode ?? "unknown")} and no output`;
               const parsed = parseAgentError(errSource);
               const msg = formatErrorForUser(parsed);
               log.error("cursor-cli streaming failed", {
                 type: parsed.type,
-                code: child.exitCode,
+                code: exitCode,
               });
               const errChunk = createChatCompletionChunk(id, created, model, msg, true);
               controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
@@ -825,7 +850,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
             }
 
             log.debug("cursor-agent completed (bun stream)", {
-              exitCode: child.exitCode,
+              exitCode,
             });
             const doneChunk = createChatCompletionChunk(id, created, model, "", true);
             controller.enqueue(encoder.encode(`data: ${JSON.stringify(doneChunk)}\n\n`));
@@ -860,8 +885,12 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
     try {
       const res = await fetch(`http://${CURSOR_PROXY_HOST}:${CURSOR_PROXY_DEFAULT_PORT}/health`).catch(() => null);
       if (res && res.ok) {
-        g[key].baseURL = CURSOR_PROXY_DEFAULT_BASE_URL;
-        return CURSOR_PROXY_DEFAULT_BASE_URL;
+        const payload = await res.json().catch(() => null);
+        if (isReusableProxyHealthPayload(payload, workspaceDirectory)) {
+          state.baseURL = CURSOR_PROXY_DEFAULT_BASE_URL;
+          state.baseURLByWorkspace![normalizedWorkspace] = CURSOR_PROXY_DEFAULT_BASE_URL;
+          return CURSOR_PROXY_DEFAULT_BASE_URL;
+        }
       }
     } catch {
       // ignore
@@ -878,7 +907,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
       if (url.pathname === "/health") {
         res.writeHead(200, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ ok: true }));
+        res.end(JSON.stringify({ ok: true, workspaceDirectory }));
         return;
       }
 
@@ -1326,7 +1355,8 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
     });
 
     const baseURL = `http://${CURSOR_PROXY_HOST}:${CURSOR_PROXY_DEFAULT_PORT}/v1`;
-    g[key].baseURL = baseURL;
+    state.baseURL = baseURL;
+    state.baseURLByWorkspace![normalizedWorkspace] = baseURL;
     return baseURL;
   } catch (error: any) {
     if (error?.code !== "EADDRINUSE") {
@@ -1338,8 +1368,12 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
       try {
         const res = await fetch(`http://${CURSOR_PROXY_HOST}:${CURSOR_PROXY_DEFAULT_PORT}/health`).catch(() => null);
         if (res && res.ok) {
-          g[key].baseURL = CURSOR_PROXY_DEFAULT_BASE_URL;
-          return CURSOR_PROXY_DEFAULT_BASE_URL;
+          const payload = await res.json().catch(() => null);
+          if (isReusableProxyHealthPayload(payload, workspaceDirectory)) {
+            state.baseURL = CURSOR_PROXY_DEFAULT_BASE_URL;
+            state.baseURLByWorkspace![normalizedWorkspace] = CURSOR_PROXY_DEFAULT_BASE_URL;
+            return CURSOR_PROXY_DEFAULT_BASE_URL;
+          }
         }
       } catch {
         // ignore
@@ -1355,7 +1389,8 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
     const addr = server.address() as any;
     const baseURL = `http://${CURSOR_PROXY_HOST}:${addr.port}/v1`;
-    g[key].baseURL = baseURL;
+    state.baseURL = baseURL;
+    state.baseURLByWorkspace![normalizedWorkspace] = baseURL;
     return baseURL;
   }
 }

--- a/tests/unit/plugin-proxy-reuse.test.ts
+++ b/tests/unit/plugin-proxy-reuse.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { isReusableProxyHealthPayload, normalizeWorkspaceForCompare } from "../../src/plugin.js";
+
+describe("proxy health reuse guard", () => {
+  test("rejects payloads without ok=true", () => {
+    expect(isReusableProxyHealthPayload(null, "/tmp/project")).toBe(false);
+    expect(isReusableProxyHealthPayload({ ok: false }, "/tmp/project")).toBe(false);
+  });
+
+  test("rejects payloads without workspace identity", () => {
+    expect(isReusableProxyHealthPayload({ ok: true }, "/tmp/project")).toBe(false);
+    expect(isReusableProxyHealthPayload({ ok: true, workspaceDirectory: "" }, "/tmp/project")).toBe(false);
+  });
+
+  test("accepts matching workspace identity", () => {
+    const workspace = "/tmp/project";
+    expect(isReusableProxyHealthPayload({ ok: true, workspaceDirectory: workspace }, workspace)).toBe(true);
+  });
+
+  test("rejects mismatched workspace identity", () => {
+    expect(
+      isReusableProxyHealthPayload(
+        { ok: true, workspaceDirectory: "/tmp/other-project" },
+        "/tmp/project",
+      ),
+    ).toBe(false);
+  });
+
+  test("normalizes paths deterministically for comparisons", () => {
+    const normalized = normalizeWorkspaceForCompare("./tests/../tests");
+    expect(typeof normalized).toBe("string");
+    expect(normalized.length).toBeGreaterThan(0);
+  });
+
+});


### PR DESCRIPTION
The plugin reuses an existing proxy on 127.0.0.1:32124 by checking `/health`.
`/health` did not include workspace identity, so a proxy started in one workspace (e.g. ~/.config/opencode) could be reused by sessions in another workspace (e.g. ~/git/foo).
Result: `cursor-agent` runs with stale --workspace, and file writes are incorrectly blocked outside that stale directory.


Root fix:
- Proxy reuse is now workspace-aware:
  - `/health` includes workspaceDirectory
  - reuse only occurs when health workspace matches requested workspace otherwise start a fresh proxy (including random-port fallback on EADDRINUSE)
  - Workspace comparison is normalised and platform-aware:
  - Bun streaming now waits for actual process exit `await child.exited` before deciding success vs error, preventing premature SSE termination.
    
    
Adjacent SSE fix:
In Bun streaming path, completion/error decision relied on `child.exitCode` directly, which can be null until process fully exits.
This race can emit terminal/error behaviour prematurely and truncate SSE output.

Full disclosure, AI was used in this PR and I don't claim to have taken the time to understand Plugin.ts however, I have tested this for this machine and can confirm that this plugin now 'works on my machine'.