### PR TITLE
fix: resolve plugin loading crash by isolating entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.2",
   "description": "No prompt limits. No broken streams. Full thinking + tool support. Your Cursor subscription, properly integrated.",
   "type": "module",
-  "main": "dist/index.js",
+  "main": "dist/plugin-entry.js",
   "module": "src/plugin-entry.ts",
   "scripts": {
     "build": "bun build ./src/index.ts ./src/plugin-entry.ts ./src/cli/discover.ts ./src/cli/opencode-cursor.ts --outdir ./dist --target node",
@@ -23,6 +23,11 @@
   "exports": {
     ".": {
       "bun": "./src/plugin-entry.ts",
+      "import": "./dist/plugin-entry.js",
+      "default": "./dist/plugin-entry.js"
+    },
+    "./lib": {
+      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     }

--- a/src/plugin-toggle.ts
+++ b/src/plugin-toggle.ts
@@ -3,6 +3,14 @@ import { homedir } from "os";
 import { join, resolve } from "path";
 
 const CURSOR_PROVIDER_ID = "cursor-acp";
+const NPM_PACKAGE_NAME = "@rama_nigg/open-cursor";
+
+function matchesPlugin(entry: string): boolean {
+  if (entry === CURSOR_PROVIDER_ID) return true;
+  if (entry === NPM_PACKAGE_NAME) return true;
+  if (entry.startsWith(`${NPM_PACKAGE_NAME}@`)) return true;
+  return false;
+}
 
 type EnvLike = Record<string, string | undefined>;
 
@@ -26,7 +34,7 @@ export function isCursorPluginEnabledInConfig(config: unknown): boolean {
   const configObject = config as { plugin?: unknown; provider?: unknown };
 
   if (Array.isArray(configObject.plugin)) {
-    return configObject.plugin.some((entry) => entry === CURSOR_PROVIDER_ID);
+    return configObject.plugin.some((entry) => matchesPlugin(entry));
   }
 
   return true;

--- a/tests/unit/plugin-toggle.test.ts
+++ b/tests/unit/plugin-toggle.test.ts
@@ -14,6 +14,14 @@ describe("plugin toggle", () => {
     expect(isCursorPluginEnabledInConfig({ plugin: ["cursor-acp"] })).toBe(true);
   });
 
+  it("enables plugin when plugin array includes npm package name", () => {
+    expect(isCursorPluginEnabledInConfig({ plugin: ["@rama_nigg/open-cursor"] })).toBe(true);
+  });
+
+  it("enables plugin when plugin array includes npm package name with version", () => {
+    expect(isCursorPluginEnabledInConfig({ plugin: ["@rama_nigg/open-cursor@2.3.2"] })).toBe(true);
+  });
+
   it("disables plugin when plugin array excludes cursor-acp", () => {
     expect(isCursorPluginEnabledInConfig({ plugin: ["other-plugin"] })).toBe(false);
   });


### PR DESCRIPTION
## Problem

OpenCode's plugin loader calls every export from a plugin module as `fn(input)`. When `dist/index.js` exports utility classes like `DeltaTracker`, calling them without `new` causes:

```
TypeError: Cannot call a class constructor DeltaTracker without |new|
```

This makes the plugin non-functional (Issue #34).

## Solution

1. **Isolate entry point**: Change `main` to `dist/plugin-entry.js` which exports only the plugin function as default
2. **Preserve library access**: Add `./lib` subpath export for programmatic consumers who need the full API
3. **Fix plugin detection**: Add `matchesPlugin()` helper to recognize:
   - `cursor-acp` (legacy name)
   - `@rama_nigg/open-cursor` (npm package name)
   - `@rama_nigg/open-cursor@version` (with version suffix)

## Testing

- Added unit tests for npm package name matching
- All 404 tests pass (1 pre-existing failure in loop-guard unrelated to this PR)
- Build succeeds

Fixes #34