### PR TITLE
fix: prevent duplicated output in DeltaTracker when prefix drifts

### DIFF
--- a/src/streaming/delta-tracker.ts
+++ b/src/streaming/delta-tracker.ts
@@ -24,10 +24,24 @@ export class DeltaTracker {
       return current;
     }
 
+    // Happy path: accumulated text grows with exact prefix match
     if (current.startsWith(previous)) {
       return current.slice(previous.length);
     }
 
-    return current;
+    // Accumulated text was already fully emitted (e.g. duplicate or trimmed event)
+    if (previous.startsWith(current)) {
+      return "";
+    }
+
+    // Prefix mismatch (formatting drift, unicode normalization, whitespace changes):
+    // find longest common prefix and emit only the new suffix.
+    // This prevents re-emitting the entire accumulated text as a "delta".
+    let i = 0;
+    const minLen = Math.min(previous.length, current.length);
+    while (i < minLen && previous[i] === current[i]) {
+      i++;
+    }
+    return current.slice(i);
   }
 }

--- a/tests/unit/streaming/delta-tracker.test.ts
+++ b/tests/unit/streaming/delta-tracker.test.ts
@@ -16,11 +16,26 @@ describe("DeltaTracker", () => {
     expect(tracker.nextText("Hello world")).toBe(" world");
   });
 
-  it("returns full text when not a prefix", () => {
+  it("returns only new suffix when prefix drifts", () => {
     const tracker = new DeltaTracker();
 
     expect(tracker.nextText("Hello")).toBe("Hello");
-    expect(tracker.nextText("Hi there")).toBe("Hi there");
+    // "Hello" vs "Hi there" share prefix "H", so delta = "i there"
+    expect(tracker.nextText("Hi there")).toBe("i there");
+  });
+
+  it("returns empty string for duplicate event", () => {
+    const tracker = new DeltaTracker();
+
+    expect(tracker.nextText("Hello world")).toBe("Hello world");
+    expect(tracker.nextText("Hello world")).toBe("");
+  });
+
+  it("returns empty string when current is substring of previous", () => {
+    const tracker = new DeltaTracker();
+
+    expect(tracker.nextText("Hello world")).toBe("Hello world");
+    expect(tracker.nextText("Hello")).toBe("");
   });
 
   it("handles unicode text", () => {
@@ -28,6 +43,33 @@ describe("DeltaTracker", () => {
 
     expect(tracker.nextText("Hi 😀")).toBe("Hi 😀");
     expect(tracker.nextText("Hi 😀!!")).toBe("!!");
+  });
+
+  it("handles trailing whitespace drift without duplication", () => {
+    const tracker = new DeltaTracker();
+
+    expect(tracker.nextText("Line one\n")).toBe("Line one\n");
+    expect(tracker.nextText("Line one\nLine two")).toBe("Line two");
+  });
+
+  it("handles accumulated text with minor formatting change", () => {
+    const tracker = new DeltaTracker();
+
+    expect(tracker.nextText("Hello world.")).toBe("Hello world.");
+    expect(tracker.nextText("Hello world. Goodbye.")).toBe(" Goodbye.");
+  });
+
+  it("does not re-emit full text on mid-stream prefix mismatch", () => {
+    const tracker = new DeltaTracker();
+    const base = "The quick brown fox jumps over the lazy dog.";
+
+    expect(tracker.nextText(base)).toBe(base);
+    // Simulate formatting drift: same text but with an extra space inserted mid-stream
+    const drifted = "The quick brown fox  jumps over the lazy dog. And more.";
+    const result = tracker.nextText(drifted);
+    // Common prefix is "The quick brown fox " (20 chars), delta is " jumps over..."
+    expect(result.length).toBeLessThan(drifted.length);
+    expect(result).not.toBe(drifted);
   });
 
   it("tracks thinking separately", () => {


### PR DESCRIPTION
## Problem

Fixes #39 — model output is shown twice for long streaming responses.

## Root Cause

`DeltaTracker.diff()` assumes accumulated text always grows with an exact prefix match (`current.startsWith(previous)`). When `cursor-agent` emits accumulated text where the current value diverges from the previous (formatting drift, unicode normalization, whitespace changes), the method falls through to `return current` — re-emitting the **entire** accumulated text as a "delta". OpenCode concatenates all deltas, producing duplicated output.

This explains why:
- **Short responses** don't duplicate (single event, no prefix comparison needed)
- **Thinking** doesn't duplicate (thinking events are true deltas, not accumulated)
- **Long streaming responses** duplicate (multiple accumulated events, higher chance of prefix mismatch)

## Fix

Three changes to `DeltaTracker.diff()`:

1. **Exact prefix match** (existing, unchanged): `current.startsWith(previous)` → emit suffix
2. **Reverse containment** (new): `previous.startsWith(current)` → return empty string (duplicate/trimmed event)
3. **Prefix mismatch** (new): find longest common prefix via character comparison, emit only the new suffix

## Tests

- Updated `delta-tracker.test.ts` with 5 new test cases covering:
  - Prefix drift scenarios
  - Duplicate event handling
  - Reverse containment (current shorter than previous)
  - Mid-stream formatting changes
  - All 11 tests pass
