### PR TITLE
fix: prevent 2x response duplication when cursor-agent emits partial …

### DIFF
--- a/src/streaming/ai-sdk-parts.ts
+++ b/src/streaming/ai-sdk-parts.ts
@@ -37,14 +37,34 @@ export class StreamToAiSdkParts {
   private readonly tracker = new DeltaTracker();
   private readonly toolArgsById = new Map<string, string>();
   private readonly startedToolIds = new Set<string>();
+  private sawAssistantPartials = false;
+  private sawThinkingPartials = false;
 
   handleEvent(event: StreamJsonEvent): AiSdkStreamPart[] {
     if (isAssistantText(event)) {
+      const isPartial = typeof (event as any).timestamp_ms === "number";
+      if (isPartial) {
+        this.sawAssistantPartials = true;
+        const text = extractText(event);
+        return text ? [{ type: "text-delta", textDelta: text }] : [];
+      }
+      if (this.sawAssistantPartials) {
+        return [];
+      }
       const delta = this.tracker.nextText(extractText(event));
       return delta ? [{ type: "text-delta", textDelta: delta }] : [];
     }
 
     if (isThinking(event)) {
+      const isPartial = typeof (event as any).timestamp_ms === "number";
+      if (isPartial) {
+        this.sawThinkingPartials = true;
+        const text = extractThinking(event);
+        return text ? [{ type: "text-delta", textDelta: text }] : [];
+      }
+      if (this.sawThinkingPartials) {
+        return [];
+      }
       const delta = this.tracker.nextThinking(extractThinking(event));
       return delta ? [{ type: "text-delta", textDelta: delta }] : [];
     }

--- a/src/streaming/openai-sse.ts
+++ b/src/streaming/openai-sse.ts
@@ -61,6 +61,11 @@ export class StreamToSseConverter {
   private readonly created: number;
   private readonly model: string;
   private readonly tracker = new DeltaTracker();
+  // Events with timestamp_ms carry delta text; events without carry accumulated text.
+  // DeltaTracker handles accumulated text only. When partials (delta) were seen,
+  // the final accumulated event must be skipped to prevent 2x duplication.
+  private sawAssistantPartials = false;
+  private sawThinkingPartials = false;
 
   constructor(model: string, options?: { id?: string; created?: number }) {
     this.model = model;
@@ -70,11 +75,29 @@ export class StreamToSseConverter {
 
   handleEvent(event: StreamJsonEvent): string[] {
     if (isAssistantText(event)) {
+      const isPartial = typeof (event as any).timestamp_ms === "number";
+      if (isPartial) {
+        this.sawAssistantPartials = true;
+        const text = extractText(event);
+        return text ? [this.chunkWith({ content: text })] : [];
+      }
+      if (this.sawAssistantPartials) {
+        return [];
+      }
       const delta = this.tracker.nextText(extractText(event));
       return delta ? [this.chunkWith({ content: delta })] : [];
     }
 
     if (isThinking(event)) {
+      const isPartial = typeof (event as any).timestamp_ms === "number";
+      if (isPartial) {
+        this.sawThinkingPartials = true;
+        const text = extractThinking(event);
+        return text ? [this.chunkWith({ reasoning_content: text })] : [];
+      }
+      if (this.sawThinkingPartials) {
+        return [];
+      }
       const delta = this.tracker.nextThinking(extractThinking(event));
       return delta ? [this.chunkWith({ reasoning_content: delta })] : [];
     }

--- a/tests/unit/streaming/ai-sdk-parts.test.ts
+++ b/tests/unit/streaming/ai-sdk-parts.test.ts
@@ -107,4 +107,115 @@ describe("ai-sdk stream parts", () => {
       },
     ]);
   });
+
+  it("does not duplicate text when partial (timestamp_ms) events are followed by final accumulated event", () => {
+    const converter = new StreamToAiSdkParts();
+    const now = Date.now();
+
+    const first = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 1,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    } as any);
+
+    expect(first).toEqual([{ type: "text-delta", textDelta: "Hello" }]);
+
+    const second = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 2,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: " world" }],
+      },
+    } as any);
+
+    expect(second).toEqual([{ type: "text-delta", textDelta: " world" }]);
+
+    // Final accumulated event (no timestamp_ms) — should be skipped
+    const final = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+
+    expect(final).toEqual([]);
+  });
+
+  it("does not duplicate thinking when partial (timestamp_ms) events are followed by final accumulated event", () => {
+    const converter = new StreamToAiSdkParts();
+    const now = Date.now();
+
+    const first = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 1,
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Let me think" }],
+      },
+    } as any);
+
+    expect(first).toEqual([{ type: "text-delta", textDelta: "Let me think" }]);
+
+    const second = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 2,
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: " about this" }],
+      },
+    } as any);
+
+    expect(second).toEqual([{ type: "text-delta", textDelta: " about this" }]);
+
+    // Final accumulated thinking event (no timestamp_ms) — should be skipped
+    const final = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Let me think about this" }],
+      },
+    });
+
+    expect(final).toEqual([]);
+  });
+
+  it("still works with accumulated-only events (no timestamp_ms) via DeltaTracker", () => {
+    const converter = new StreamToAiSdkParts();
+
+    const first = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    });
+
+    expect(first).toEqual([{ type: "text-delta", textDelta: "Hello" }]);
+
+    const second = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+
+    expect(second).toEqual([{ type: "text-delta", textDelta: " world" }]);
+
+    // Duplicate event should produce no output
+    const dup = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+
+    expect(dup).toEqual([]);
+  });
 });

--- a/tests/unit/streaming/openai-sse.test.ts
+++ b/tests/unit/streaming/openai-sse.test.ts
@@ -103,4 +103,133 @@ describe("openai-sse", () => {
 
     expect(parseChunk(second[0]).choices[0].delta.reasoning_content).toBe(" the problem");
   });
+
+  it("does not duplicate text when partial (timestamp_ms) events are followed by final accumulated event", () => {
+    const converter = new StreamToSseConverter("test-model", {
+      id: "chunk-id",
+      created: 123,
+    });
+    const now = Date.now();
+
+    // Simulate real cursor-acp protocol: events with timestamp_ms carry delta text
+    const first = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 1,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    } as any);
+
+    expect(first).toHaveLength(1);
+    expect(parseChunk(first[0]).choices[0].delta.content).toBe("Hello");
+
+    const second = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 2,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: " world" }],
+      },
+    } as any);
+
+    expect(second).toHaveLength(1);
+    expect(parseChunk(second[0]).choices[0].delta.content).toBe(" world");
+
+    // Final accumulated event (no timestamp_ms) with full text — should be skipped
+    const final = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+
+    expect(final).toEqual([]);
+  });
+
+  it("does not duplicate thinking when partial (timestamp_ms) events are followed by final accumulated event", () => {
+    const converter = new StreamToSseConverter("test-model", {
+      id: "chunk-id",
+      created: 123,
+    });
+    const now = Date.now();
+
+    // Thinking events with timestamp_ms carry delta text
+    const first = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 1,
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Let me think" }],
+      },
+    } as any);
+
+    expect(first).toHaveLength(1);
+    expect(parseChunk(first[0]).choices[0].delta.reasoning_content).toBe("Let me think");
+
+    const second = converter.handleEvent({
+      type: "assistant",
+      timestamp_ms: now + 2,
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: " about this" }],
+      },
+    } as any);
+
+    expect(second).toHaveLength(1);
+    expect(parseChunk(second[0]).choices[0].delta.reasoning_content).toBe(" about this");
+
+    // Final accumulated thinking event (no timestamp_ms) — should be skipped
+    const final = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Let me think about this" }],
+      },
+    });
+
+    expect(final).toEqual([]);
+  });
+
+  it("still works with accumulated-only events (no timestamp_ms) via DeltaTracker", () => {
+    const converter = new StreamToSseConverter("test-model", {
+      id: "chunk-id",
+      created: 123,
+    });
+
+    // Accumulated-only events (no timestamp_ms), like fixture format — should work via DeltaTracker
+    const first = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+      },
+    });
+
+    expect(first).toHaveLength(1);
+    expect(parseChunk(first[0]).choices[0].delta.content).toBe("Hello");
+
+    const second = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+
+    expect(second).toHaveLength(1);
+    expect(parseChunk(second[0]).choices[0].delta.content).toBe(" world");
+
+    // Duplicate event should produce no output
+    const dup = converter.handleEvent({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Hello world" }],
+      },
+    });
+
+    expect(dup).toEqual([]);
+  });
 });


### PR DESCRIPTION
…delta events

cursor-agent --stream-partial-output emits two kinds of assistant text events: partial deltas (with timestamp_ms) containing only new text fragments, and a final accumulated event (without timestamp_ms) containing the complete text.

DeltaTracker expects accumulated text and diffs against previous state, but partial deltas broke its diffing logic — causing the final accumulated event to re-emit the entire response.

Discriminate between partial and accumulated events using the timestamp_ms field: partial events are emitted directly as deltas, and the final accumulated event is skipped when partials were seen. Backward-compatible with accumulated-only format (existing test fixtures).