### PR TITLE
fix(plugin): reject '/' as workspace, fall back to $HOME

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -219,37 +219,76 @@ function isNonConfigPath(pathValue: string): boolean {
   return !isWithinPath(getOpenCodeConfigPrefix(), pathValue);
 }
 
+// Filesystem roots are never a meaningful workspace: accepting "/" (or a bare
+// Windows drive root like "C:\") makes every tool treat the whole machine as
+// the project, which is both unsafe and a common symptom of a daemon that
+// was launched without a real cwd (e.g. systemd unit without WorkingDirectory).
+export function isRootPath(pathValue: string): boolean {
+  if (!pathValue) {
+    return false;
+  }
+  const resolved = resolve(pathValue);
+  if (resolved === "/") {
+    return true;
+  }
+  return /^[A-Za-z]:[\\/]?$/.test(resolved);
+}
+
+function isAcceptableWorkspace(pathValue: string, configPrefix: string): boolean {
+  if (!pathValue) {
+    return false;
+  }
+  if (isRootPath(pathValue)) {
+    return false;
+  }
+  if (isWithinPath(configPrefix, pathValue)) {
+    return false;
+  }
+  return true;
+}
+
 const SESSION_WORKSPACE_CACHE_LIMIT = 200;
 
-function resolveWorkspaceDirectory(worktree: string | undefined, directory: string | undefined): string {
-  const envWorkspace = process.env.CURSOR_ACP_WORKSPACE?.trim();
-  if (envWorkspace) {
-    return resolve(envWorkspace);
-  }
-
-  const envProjectDir = process.env.OPENCODE_CURSOR_PROJECT_DIR?.trim();
-  if (envProjectDir) {
-    return resolve(envProjectDir);
-  }
-
+export function resolveWorkspaceDirectory(
+  worktree: string | undefined,
+  directory: string | undefined,
+): string {
   const configPrefix = getOpenCodeConfigPrefix();
 
+  const envWorkspace = resolveCandidate(process.env.CURSOR_ACP_WORKSPACE);
+  if (envWorkspace && !isRootPath(envWorkspace)) {
+    return envWorkspace;
+  }
+
+  const envProjectDir = resolveCandidate(process.env.OPENCODE_CURSOR_PROJECT_DIR);
+  if (envProjectDir && !isRootPath(envProjectDir)) {
+    return envProjectDir;
+  }
+
   const worktreeCandidate = resolveCandidate(worktree);
-  if (worktreeCandidate && !isWithinPath(configPrefix, worktreeCandidate)) {
+  if (isAcceptableWorkspace(worktreeCandidate, configPrefix)) {
     return worktreeCandidate;
   }
 
   const dirCandidate = resolveCandidate(directory);
-  if (dirCandidate && !isWithinPath(configPrefix, dirCandidate)) {
+  if (isAcceptableWorkspace(dirCandidate, configPrefix)) {
     return dirCandidate;
   }
 
   const cwd = resolve(process.cwd());
-  if (cwd && !isWithinPath(configPrefix, cwd)) {
+  if (isAcceptableWorkspace(cwd, configPrefix)) {
     return cwd;
   }
 
-  return dirCandidate || cwd || configPrefix;
+  // Fall back to the user's home directory rather than "/" when every other
+  // signal is unusable. $HOME is always writable for the current user and
+  // keeps tool scopes sane even when the daemon was spawned from root.
+  const home = resolveCandidate(homedir());
+  if (home && !isRootPath(home)) {
+    return home;
+  }
+
+  return configPrefix;
 }
 
 type ProxyRuntimeState = {

--- a/tests/unit/plugin-workspace-resolution.test.ts
+++ b/tests/unit/plugin-workspace-resolution.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join, resolve } from "path";
+
+import { resolveWorkspaceDirectory, isRootPath } from "../../src/plugin";
+
+describe("isRootPath", () => {
+  it("recognises the POSIX root", () => {
+    expect(isRootPath("/")).toBe(true);
+  });
+
+  it.if(process.platform === "win32")("recognises Windows drive roots", () => {
+    expect(isRootPath("C:\\")).toBe(true);
+    expect(isRootPath("D:/")).toBe(true);
+    expect(isRootPath("C:")).toBe(true);
+  });
+
+  it("rejects ordinary paths", () => {
+    expect(isRootPath("/home/user")).toBe(false);
+    expect(isRootPath("/tmp")).toBe(false);
+    expect(isRootPath("")).toBe(false);
+  });
+});
+
+describe("resolveWorkspaceDirectory", () => {
+  let previousXdgConfigHome: string | undefined;
+  let previousWorkspaceEnv: string | undefined;
+  let previousProjectDirEnv: string | undefined;
+  let previousCwd: string;
+  let tempConfigHome: string;
+  let tempWorkspace: string;
+
+  beforeEach(() => {
+    previousXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    previousWorkspaceEnv = process.env.CURSOR_ACP_WORKSPACE;
+    previousProjectDirEnv = process.env.OPENCODE_CURSOR_PROJECT_DIR;
+    previousCwd = process.cwd();
+
+    tempConfigHome = mkdtempSync(join(tmpdir(), "opencode-cursor-cfg-"));
+    tempWorkspace = mkdtempSync(join(tmpdir(), "opencode-cursor-ws-"));
+    process.env.XDG_CONFIG_HOME = tempConfigHome;
+    delete process.env.CURSOR_ACP_WORKSPACE;
+    delete process.env.OPENCODE_CURSOR_PROJECT_DIR;
+  });
+
+  afterEach(() => {
+    try {
+      process.chdir(previousCwd);
+    } catch {
+      // best-effort restore
+    }
+
+    if (previousXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = previousXdgConfigHome;
+    }
+    if (previousWorkspaceEnv === undefined) {
+      delete process.env.CURSOR_ACP_WORKSPACE;
+    } else {
+      process.env.CURSOR_ACP_WORKSPACE = previousWorkspaceEnv;
+    }
+    if (previousProjectDirEnv === undefined) {
+      delete process.env.OPENCODE_CURSOR_PROJECT_DIR;
+    } else {
+      process.env.OPENCODE_CURSOR_PROJECT_DIR = previousProjectDirEnv;
+    }
+
+    rmSync(tempConfigHome, { recursive: true, force: true });
+    rmSync(tempWorkspace, { recursive: true, force: true });
+  });
+
+  it("prefers a real worktree over cwd", () => {
+    const result = resolveWorkspaceDirectory(tempWorkspace, undefined);
+    expect(result).toBe(resolve(tempWorkspace));
+  });
+
+  it("prefers directory when worktree is missing", () => {
+    const result = resolveWorkspaceDirectory(undefined, tempWorkspace);
+    expect(result).toBe(resolve(tempWorkspace));
+  });
+
+  it("rejects '/' from worktree and directory and falls back to cwd", () => {
+    process.chdir(tempWorkspace);
+    const result = resolveWorkspaceDirectory("/", "/");
+    expect(result).toBe(resolve(tempWorkspace));
+  });
+
+  it("falls back to $HOME when worktree, directory, and cwd are all '/'", () => {
+    process.chdir("/");
+    const result = resolveWorkspaceDirectory("/", "/");
+    expect(result).toBe(resolve(homedir()));
+    expect(result).not.toBe("/");
+  });
+
+  it("rejects '/' provided via CURSOR_ACP_WORKSPACE", () => {
+    process.env.CURSOR_ACP_WORKSPACE = "/";
+    process.chdir(tempWorkspace);
+    const result = resolveWorkspaceDirectory(undefined, undefined);
+    expect(result).toBe(resolve(tempWorkspace));
+  });
+
+  it("rejects '/' provided via OPENCODE_CURSOR_PROJECT_DIR", () => {
+    process.env.OPENCODE_CURSOR_PROJECT_DIR = "/";
+    process.chdir(tempWorkspace);
+    const result = resolveWorkspaceDirectory(undefined, undefined);
+    expect(result).toBe(resolve(tempWorkspace));
+  });
+
+  it("respects CURSOR_ACP_WORKSPACE when it is a real directory", () => {
+    process.env.CURSOR_ACP_WORKSPACE = tempWorkspace;
+    const result = resolveWorkspaceDirectory(undefined, undefined);
+    expect(result).toBe(resolve(tempWorkspace));
+  });
+
+  it("skips paths inside the opencode config prefix", () => {
+    const insideConfig = join(tempConfigHome, "opencode", "plugin");
+    const result = resolveWorkspaceDirectory(insideConfig, insideConfig);
+    expect(result).not.toBe(insideConfig);
+  });
+});


### PR DESCRIPTION
## Summary

- `resolveWorkspaceDirectory` previously accepted any path it was handed, including a bare filesystem root (`/`). When opencode is launched without a real cwd (systemd unit, login shell at `/`, daemon spawned by root), `worktree`, `directory`, and `process.cwd()` can all resolve to `/`, which silently makes every tool operate against the whole machine and bypasses workspace scoping.
- Every candidate — env vars (`CURSOR_ACP_WORKSPACE`, `OPENCODE_CURSOR_PROJECT_DIR`), `worktree`, `directory`, and `cwd` — is now rejected if it resolves to `/` (or a bare Windows drive root like `C:\`).
- When no usable workspace is found we fall back to the current user's home directory before the OpenCode config prefix, so tools always land in a writable, user-scoped location instead of `/`.
- `resolveWorkspaceDirectory` and a new `isRootPath` helper are exported so the behaviour is unit-testable.

## Why

The bundled `~/.config/opencode/plugin/cursor-acp.js` was hot-patched in the field to work around this. This PR lands the same fix in the TypeScript source (`src/plugin.ts`) so a fresh `bun run build` produces a plugin that is safe by default.

## Changes

- `src/plugin.ts`
  - Add `isRootPath(pathValue)` — detects `/` and bare Windows drive roots.
  - Add `isAcceptableWorkspace(path, configPrefix)` — rejects empty, root, and config-prefix paths in one place.
  - Reorder `resolveWorkspaceDirectory` so the `configPrefix` is computed once, each candidate goes through `isAcceptableWorkspace`, and a `$HOME` fallback is consulted before the config prefix.
  - Export `resolveWorkspaceDirectory` and `isRootPath`.
- `tests/unit/plugin-workspace-resolution.test.ts` (new)
  - `isRootPath` covers POSIX root, Windows drive roots (skipped off-Windows), and ordinary paths.
  - `resolveWorkspaceDirectory` covers: worktree preferred, directory fallback, `/` rejected from worktree/directory (falls back to cwd), `/` everywhere (falls back to `\$HOME`), env-var `/` rejection for both env vars, honoring a real env workspace, and skipping paths inside the config prefix.

## Test plan

- [x] `bun test tests/unit/plugin-workspace-resolution.test.ts` — 10 pass, 1 skipped (Windows-only case).
- [x] `bun test tests/unit/plugin.test.ts tests/unit/plugin-config.test.ts` — no regressions.
- [x] `bun run build` — bundles cleanly.
- [ ] Reviewer: verify on a real systemd-spawned daemon that the plugin no longer treats `/` as the workspace.

Note: `tests/unit/plugin-tools-hook.test.ts > treats config path aliases (symlink/case variants) as config and falls back to workspace` fails on `main` as well (unrelated symlink/tmp handling); not addressed here.

Made with [Cursor](https://cursor.com)