### PR TITLE
feat: support cursor model variants at runtime

### DIFF
--- a/docs/architecture/runtime-tool-loop.md
+++ b/docs/architecture/runtime-tool-loop.md
@@ -67,6 +67,10 @@ This lets a compact OpenCode model such as `cursor-acp/gpt-5.3-codex` call a con
 
 Use `--dry-run` to preview the model sync without writing the config. Sync output includes added, updated, removed, priced, and skipped counts so repeated syncs are easy to audit before applying them.
 
+Use `open-cursor sync-models --json` when automation needs the same sync summary as structured output. Use `open-cursor models --explain` to inspect the generated model families, default Cursor targets, variant mappings, and direct models without modifying the config.
+
+Use `open-cursor doctor --deep` after install or sync to check Cursor model discovery, provider model config, compact variant presence, and whether configured `cursorModel` targets still exist in the current `cursor-agent models` output.
+
 ## Loop Safety and Error Handling
 
 `v1` loop safety is driven by two mechanisms:

--- a/docs/architecture/runtime-tool-loop.md
+++ b/docs/architecture/runtime-tool-loop.md
@@ -65,6 +65,8 @@ This lets a compact OpenCode model such as `cursor-acp/gpt-5.3-codex` call a con
 
 `open-cursor sync-models --variants` generates those compact entries from `cursor-agent models`. The default `sync-models` command still writes direct raw Cursor model IDs. Add `--compact` with `--variants` to remove raw model entries that were folded into generated variant groups while preserving custom and unknown entries.
 
+Use `--dry-run` to preview the model sync without writing the config. Sync output includes added, updated, removed, priced, and skipped counts so repeated syncs are easy to audit before applying them.
+
 ## Loop Safety and Error Handling
 
 `v1` loop safety is driven by two mechanisms:

--- a/docs/architecture/runtime-tool-loop.md
+++ b/docs/architecture/runtime-tool-loop.md
@@ -51,6 +51,18 @@ The boundary abstraction is implemented in `src/provider/boundary.ts` and runtim
 - Tool-loop guard with fingerprinting (`src/provider/tool-loop-guard.ts`)
 - Guarded fallback to `legacy` when enabled and specific termination/error conditions are met
 
+## Model Variant Resolution
+
+OpenCode sends custom model option fields in the provider request body. When a model variant defines `cursorModel`, OpenCode merges the selected variant value into `body.cursorModel` before the request reaches `cursor-acp`.
+
+The provider boundary resolves the runtime Cursor model in this order:
+
+1. Use `body.cursorModel` when it is a non-empty string.
+2. Otherwise normalize `body.model` by stripping the `cursor-acp/` provider prefix.
+3. Fall back to `auto` when no model is available.
+
+This lets a compact OpenCode model such as `cursor-acp/gpt-5.3-codex` call a concrete Cursor model like `gpt-5.3-codex-high` when the selected variant provides that mapping.
+
 ## Loop Safety and Error Handling
 
 `v1` loop safety is driven by two mechanisms:

--- a/docs/architecture/runtime-tool-loop.md
+++ b/docs/architecture/runtime-tool-loop.md
@@ -63,6 +63,8 @@ The provider boundary resolves the runtime Cursor model in this order:
 
 This lets a compact OpenCode model such as `cursor-acp/gpt-5.3-codex` call a concrete Cursor model like `gpt-5.3-codex-high` when the selected variant provides that mapping.
 
+`open-cursor sync-models --variants` generates those compact entries from `cursor-agent models`. The default `sync-models` command still writes direct raw Cursor model IDs. Add `--compact` with `--variants` to remove raw model entries that were folded into generated variant groups while preserving custom and unknown entries.
+
 ## Loop Safety and Error Handling
 
 `v1` loop safety is driven by two mechanisms:

--- a/src/cli/opencode-cursor.ts
+++ b/src/cli/opencode-cursor.ts
@@ -18,7 +18,8 @@ import {
   discoverModelsFromCursorAgent,
   fallbackModels,
 } from "./model-discovery.js";
-import { mergeCursorModelEntries } from "../models/variants.js";
+import { groupCursorModels, mergeCursorModelEntries } from "../models/variants.js";
+import type { DiscoveredModel } from "./model-discovery.js";
 
 const BRANDING_HEADER = `
  ▄▄▄  ▄▄▄▄  ▄▄▄▄▄ ▄▄  ▄▄      ▄▄▄  ▄▄ ▄▄ ▄▄▄▄   ▄▄▄▄   ▄▄▄   ▄▄▄▄
@@ -56,6 +57,20 @@ type StatusResult = {
   };
 };
 
+type ModelExplanation = {
+  modelCount: number;
+  groupedCount: number;
+  directCount: number;
+  groups: Array<{
+    id: string;
+    name: string;
+    defaultCursorModel: string;
+    memberCount: number;
+    variants: Record<string, string>;
+  }>;
+  direct: string[];
+};
+
 export function checkBun(): CheckResult {
   try {
     const version = execFileSync("bun", ["--version"], { encoding: "utf8" }).trim();
@@ -87,7 +102,11 @@ export function checkCursorAgentLogin(): CheckResult {
   try {
     // cursor-agent stores credentials in ~/.cursor-agent or similar
     // Try running a command that requires auth
-    execFileSync("cursor-agent", ["models"], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    execFileSync("cursor-agent", ["models"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 3000,
+    });
     return { name: "cursor-agent login", passed: true, message: "logged in" };
   } catch {
     return {
@@ -218,7 +237,7 @@ export function runDoctorChecks(configPath: string, pluginPath: string): CheckRe
   ];
 }
 
-type Command = "install" | "sync-models" | "uninstall" | "status" | "doctor" | "help";
+type Command = "install" | "sync-models" | "models" | "uninstall" | "status" | "doctor" | "help";
 
 type Options = {
   config?: string;
@@ -230,6 +249,8 @@ type Options = {
   variants?: boolean;
   compact?: boolean;
   dryRun?: boolean;
+  deep?: boolean;
+  explain?: boolean;
   json?: boolean;
 };
 
@@ -248,6 +269,13 @@ type SyncModelsResult = {
   summary: SyncSummary;
 };
 
+type SyncModelsJsonResult = SyncModelsResult & {
+  configPath: string;
+  dryRun: boolean;
+  variants: boolean;
+  compact: boolean;
+};
+
 const PROVIDER_ID = "cursor-acp";
 const NPM_PACKAGE_PREFIX = "@rama_nigg/open-cursor";
 const DEFAULT_BASE_URL = "http://127.0.0.1:32124/v1";
@@ -260,6 +288,7 @@ function printHelp() {
 Commands:
   install     Configure OpenCode for Cursor (idempotent, safe to re-run)
   sync-models Refresh model list from cursor-agent
+  models      Explain discovered Cursor model groups and variants
   status      Show current configuration state
   doctor      Diagnose common issues
   uninstall   Remove cursor-acp from OpenCode config
@@ -274,8 +303,10 @@ Options:
   --variants            Generate compact OpenCode model variants from Cursor models
   --compact             With --variants, remove raw grouped Cursor model entries
   --dry-run             Preview sync/install config changes without writing files
+  --deep                Run extra doctor checks for models and variant config
+  --explain             Show model grouping explanation (models command)
   --no-backup           Don't create config backup
-  --json                Output in JSON format (status command only)
+  --json                Output in JSON format where supported
 `);
 }
 
@@ -296,6 +327,10 @@ function parseArgs(argv: string[]): { command: Command; options: Options } {
       options.compact = true;
     } else if (arg === "--dry-run") {
       options.dryRun = true;
+    } else if (arg === "--deep") {
+      options.deep = true;
+    } else if (arg === "--explain") {
+      options.explain = true;
     } else if (arg === "--no-backup") {
       options.noBackup = true;
     } else if (arg === "--config" && rest[i + 1]) {
@@ -321,6 +356,7 @@ function normalizeCommand(value: string | undefined): Command {
   switch ((value || "help").toLowerCase()) {
     case "install":
     case "sync-models":
+    case "models":
     case "uninstall":
     case "status":
     case "doctor":
@@ -384,12 +420,14 @@ function readConfig(configPath: string): any {
   }
 }
 
-function writeConfig(configPath: string, config: any, noBackup: boolean) {
+function writeConfig(configPath: string, config: any, noBackup: boolean, silent = false) {
   mkdirSync(dirname(configPath), { recursive: true });
   if (!noBackup && existsSync(configPath)) {
     const backupPath = `${configPath}.bak.${new Date().toISOString().replace(/[:]/g, "-")}`;
     copyFileSync(configPath, backupPath);
-    console.log(`Backup written: ${backupPath}`);
+    if (!silent) {
+      console.log(`Backup written: ${backupPath}`);
+    }
   }
   writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
 }
@@ -461,6 +499,39 @@ function syncModelsIntoProvider(config: any, options: Options): SyncModelsResult
     groupedCount: result.groupedCount,
     removedCount: result.removedCount,
     summary: summarizeModelSync(beforeModels, result.models),
+  };
+}
+
+export function explainCursorModels(models: DiscoveredModel[]): ModelExplanation {
+  const grouped = groupCursorModels(models);
+  const groupedCount = grouped.groups.reduce((total, group) => total + group.members.length, 0);
+
+  return {
+    modelCount: models.length,
+    groupedCount,
+    directCount: grouped.direct.length,
+    groups: grouped.groups.map(group => ({
+      id: group.baseId,
+      name: group.name,
+      defaultCursorModel: group.defaultCursorModelId,
+      memberCount: group.members.length,
+      variants: group.variants,
+    })),
+    direct: grouped.direct.map(model => model.id),
+  };
+}
+
+function createSyncJsonResult(
+  result: SyncModelsResult,
+  options: Options,
+  configPath: string,
+): SyncModelsJsonResult {
+  return {
+    ...result,
+    configPath,
+    dryRun: options.dryRun === true,
+    variants: options.variants === true,
+    compact: options.compact === true,
   };
 }
 
@@ -577,7 +648,12 @@ function commandSyncModels(options: Options) {
   const result = syncModelsIntoProvider(config, options);
 
   if (!options.dryRun) {
-    writeConfig(configPath, config, options.noBackup === true);
+    writeConfig(configPath, config, options.noBackup === true, options.json === true);
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify(createSyncJsonResult(result, options, configPath), null, 2));
+    return;
   }
 
   printSyncResult(result, options);
@@ -585,6 +661,46 @@ function commandSyncModels(options: Options) {
     console.log("Dry run: no changes written.");
   }
   console.log(`Config path: ${configPath}`);
+}
+
+function commandModels(options: Options) {
+  const models = discoverModelsSafe();
+  const explanation = explainCursorModels(models);
+
+  if (options.json) {
+    console.log(JSON.stringify(explanation, null, 2));
+    return;
+  }
+
+  console.log(`Cursor models discovered: ${explanation.modelCount}`);
+  console.log(`Grouped Cursor models: ${explanation.groupedCount}`);
+  console.log(`Direct models: ${explanation.directCount}`);
+
+  if (!options.explain) {
+    return;
+  }
+
+  console.log("");
+  console.log("Model groups:");
+  for (const group of explanation.groups) {
+    console.log(`  ${group.id}`);
+    console.log(`    Default: ${group.defaultCursorModel}`);
+    const variants = Object.entries(group.variants);
+    if (variants.length === 0) {
+      console.log("    Variants: none");
+      continue;
+    }
+    console.log("    Variants:");
+    for (const [variant, cursorModel] of variants) {
+      console.log(`      ${variant}: ${cursorModel}`);
+    }
+  }
+
+  console.log("");
+  console.log("Direct models:");
+  for (const modelId of explanation.direct) {
+    console.log(`  ${modelId}`);
+  }
 }
 
 function printSyncResult(result: SyncModelsResult, options: Options) {
@@ -703,6 +819,115 @@ export function getStatusResult(configPath: string, pluginPath: string): StatusR
   };
 }
 
+export function runDeepDoctorChecks(configPath: string): CheckResult[] {
+  const checks: CheckResult[] = [];
+  let config: any;
+
+  try {
+    config = readConfig(configPath);
+  } catch (error) {
+    return [{
+      name: "Deep config read",
+      passed: false,
+      message: error instanceof Error ? error.message : String(error),
+    }];
+  }
+
+  const provider = config.provider?.[PROVIDER_ID];
+  const models = isRecord(provider?.models) ? provider.models : {};
+  const baseUrl = typeof provider?.options?.baseURL === "string" ? provider.options.baseURL : "";
+
+  checks.push({
+    name: "Provider base URL",
+    passed: baseUrl.startsWith("http://") || baseUrl.startsWith("https://"),
+    message: baseUrl || "missing - run: open-cursor install",
+  });
+
+  checks.push({
+    name: "Provider models",
+    passed: Object.keys(models).length > 0,
+    message: `${Object.keys(models).length} configured model(s)`,
+  });
+
+  const variantEntryCount = countVariantModelEntries(models);
+  checks.push({
+    name: "Compact variants",
+    passed: variantEntryCount > 0,
+    warning: variantEntryCount === 0,
+    message: variantEntryCount > 0
+      ? `${variantEntryCount} model entr${variantEntryCount === 1 ? "y" : "ies"} with variants`
+      : "no compact variants found - run: open-cursor sync-models --variants --compact",
+  });
+
+  let discoveredModels: DiscoveredModel[];
+  try {
+    discoveredModels = discoverModelsFromCursorAgent();
+    checks.push({
+      name: "Cursor model discovery",
+      passed: true,
+      message: `${discoveredModels.length} model(s) from cursor-agent`,
+    });
+  } catch (error) {
+    checks.push({
+      name: "Cursor model discovery",
+      passed: false,
+      message: error instanceof Error ? error.message : String(error),
+      warning: true,
+    });
+    return checks;
+  }
+
+  const knownModelIds = new Set(discoveredModels.map(model => model.id));
+  const unknownTargets = collectConfiguredCursorModels(models)
+    .filter(modelId => !knownModelIds.has(modelId));
+  checks.push({
+    name: "Configured Cursor model targets",
+    passed: unknownTargets.length === 0,
+    warning: unknownTargets.length > 0,
+    message: unknownTargets.length === 0
+      ? "all configured targets exist in cursor-agent models"
+      : `${unknownTargets.length} target(s) not found: ${unknownTargets.slice(0, 5).join(", ")}`,
+  });
+
+  return checks;
+}
+
+function countVariantModelEntries(models: Record<string, unknown>): number {
+  return Object.values(models).filter(entry => {
+    return isRecord(entry) && isRecord(entry.variants) && Object.keys(entry.variants).length > 0;
+  }).length;
+}
+
+function collectConfiguredCursorModels(models: Record<string, unknown>): string[] {
+  const targets: string[] = [];
+
+  for (const [modelId, entry] of Object.entries(models)) {
+    if (!isRecord(entry)) {
+      targets.push(modelId);
+      continue;
+    }
+
+    const optionTarget = readCursorModel(entry.options);
+    targets.push(optionTarget || modelId);
+
+    if (!isRecord(entry.variants)) continue;
+    for (const variantEntry of Object.values(entry.variants)) {
+      const variantTarget = readCursorModel(variantEntry);
+      if (variantTarget) targets.push(variantTarget);
+    }
+  }
+
+  return [...new Set(targets)];
+}
+
+function readCursorModel(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const cursorModel = value.cursorModel;
+  return typeof cursorModel === "string" && cursorModel.trim().length > 0
+    ? cursorModel.trim()
+    : undefined;
+}
+
 function commandStatus(options: Options) {
   const { configPath, pluginPath } = resolvePaths(options);
   const result = getStatusResult(configPath, pluginPath);
@@ -739,7 +964,16 @@ function commandStatus(options: Options) {
 
 function commandDoctor(options: Options) {
   const { configPath, pluginPath } = resolvePaths(options);
-  const checks = runDoctorChecks(configPath, pluginPath);
+  const checks = [
+    ...runDoctorChecks(configPath, pluginPath),
+    ...(options.deep ? runDeepDoctorChecks(configPath) : []),
+  ];
+
+  if (options.json) {
+    const failed = checks.filter(c => !c.passed && !c.warning);
+    console.log(JSON.stringify({ deep: options.deep === true, checks, failed: failed.length }, null, 2));
+    return;
+  }
 
   console.log("");
   for (const check of checks) {
@@ -776,6 +1010,9 @@ function main() {
         return;
       case "sync-models":
         commandSyncModels(parsed.options);
+        return;
+      case "models":
+        commandModels(parsed.options);
         return;
       case "uninstall":
         commandUninstall(parsed.options);

--- a/src/cli/opencode-cursor.ts
+++ b/src/cli/opencode-cursor.ts
@@ -18,6 +18,7 @@ import {
   discoverModelsFromCursorAgent,
   fallbackModels,
 } from "./model-discovery.js";
+import { mergeCursorModelEntries } from "../models/variants.js";
 
 const BRANDING_HEADER = `
  ▄▄▄  ▄▄▄▄  ▄▄▄▄▄ ▄▄  ▄▄      ▄▄▄  ▄▄ ▄▄ ▄▄▄▄   ▄▄▄▄   ▄▄▄   ▄▄▄▄
@@ -226,6 +227,8 @@ type Options = {
   copy?: boolean;
   skipModels?: boolean;
   noBackup?: boolean;
+  variants?: boolean;
+  compact?: boolean;
   json?: boolean;
 };
 
@@ -252,6 +255,8 @@ Options:
   --base-url <url>      Proxy base URL (default: http://127.0.0.1:32124/v1)
   --copy                Copy plugin instead of symlink
   --skip-models         Skip model sync during install
+  --variants            Generate compact OpenCode model variants from Cursor models
+  --compact             With --variants, remove raw grouped Cursor model entries
   --no-backup           Don't create config backup
   --json                Output in JSON format (status command only)
 `);
@@ -268,6 +273,10 @@ function parseArgs(argv: string[]): { command: Command; options: Options } {
       options.copy = true;
     } else if (arg === "--skip-models") {
       options.skipModels = true;
+    } else if (arg === "--variants") {
+      options.variants = true;
+    } else if (arg === "--compact") {
+      options.compact = true;
     } else if (arg === "--no-backup") {
       options.noBackup = true;
     } else if (arg === "--config" && rest[i + 1]) {
@@ -411,6 +420,25 @@ function discoverModelsSafe() {
   }
 }
 
+function syncModelsIntoProvider(config: any, options: Options) {
+  if (options.compact && !options.variants) {
+    throw new Error("--compact requires --variants");
+  }
+
+  const discoveredModels = discoverModelsSafe();
+  const provider = config.provider[PROVIDER_ID];
+  const existingModels = provider.models && typeof provider.models === "object"
+    ? provider.models
+    : {};
+  const result = mergeCursorModelEntries(existingModels, discoveredModels, {
+    variants: options.variants === true,
+    compact: options.compact === true,
+  });
+
+  provider.models = result.models;
+  return result;
+}
+
 function installAiSdk(opencodeDir: string) {
   try {
     execFileSync("bun", ["install", "@ai-sdk/openai-compatible"], {
@@ -435,11 +463,14 @@ function commandInstall(options: Options) {
   ensureProvider(config, baseUrl);
 
   if (!options.skipModels) {
-    const models = discoverModelsSafe();
-    for (const model of models) {
-      config.provider[PROVIDER_ID].models[model.id] = { name: model.name };
+    const result = syncModelsIntoProvider(config, options);
+    console.log(`Models synced: ${result.syncedCount}`);
+    if (options.variants) {
+      console.log(`Grouped Cursor models: ${result.groupedCount}`);
     }
-    console.log(`Models synced: ${models.length}`);
+    if (result.removedCount > 0) {
+      console.log(`Raw grouped models removed: ${result.removedCount}`);
+    }
   }
 
   writeConfig(configPath, config, options.noBackup === true);
@@ -455,13 +486,16 @@ function commandSyncModels(options: Options) {
   const config = readConfig(configPath);
   ensureProvider(config, options.baseUrl || DEFAULT_BASE_URL);
 
-  const models = discoverModelsSafe();
-  for (const model of models) {
-    config.provider[PROVIDER_ID].models[model.id] = { name: model.name };
-  }
+  const result = syncModelsIntoProvider(config, options);
 
   writeConfig(configPath, config, options.noBackup === true);
-  console.log(`Models synced: ${models.length}`);
+  console.log(`Models synced: ${result.syncedCount}`);
+  if (options.variants) {
+    console.log(`Grouped Cursor models: ${result.groupedCount}`);
+  }
+  if (result.removedCount > 0) {
+    console.log(`Raw grouped models removed: ${result.removedCount}`);
+  }
   console.log(`Config path: ${configPath}`);
 }
 

--- a/src/cli/opencode-cursor.ts
+++ b/src/cli/opencode-cursor.ts
@@ -229,7 +229,23 @@ type Options = {
   noBackup?: boolean;
   variants?: boolean;
   compact?: boolean;
+  dryRun?: boolean;
   json?: boolean;
+};
+
+type SyncSummary = {
+  added: number;
+  updated: number;
+  removed: number;
+  priced: number;
+  skipped: number;
+};
+
+type SyncModelsResult = {
+  syncedCount: number;
+  groupedCount: number;
+  removedCount: number;
+  summary: SyncSummary;
 };
 
 const PROVIDER_ID = "cursor-acp";
@@ -257,6 +273,7 @@ Options:
   --skip-models         Skip model sync during install
   --variants            Generate compact OpenCode model variants from Cursor models
   --compact             With --variants, remove raw grouped Cursor model entries
+  --dry-run             Preview sync/install config changes without writing files
   --no-backup           Don't create config backup
   --json                Output in JSON format (status command only)
 `);
@@ -277,6 +294,8 @@ function parseArgs(argv: string[]): { command: Command; options: Options } {
       options.variants = true;
     } else if (arg === "--compact") {
       options.compact = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
     } else if (arg === "--no-backup") {
       options.noBackup = true;
     } else if (arg === "--config" && rest[i + 1]) {
@@ -420,7 +439,7 @@ function discoverModelsSafe() {
   }
 }
 
-function syncModelsIntoProvider(config: any, options: Options) {
+function syncModelsIntoProvider(config: any, options: Options): SyncModelsResult {
   if (options.compact && !options.variants) {
     throw new Error("--compact requires --variants");
   }
@@ -430,13 +449,82 @@ function syncModelsIntoProvider(config: any, options: Options) {
   const existingModels = provider.models && typeof provider.models === "object"
     ? provider.models
     : {};
+  const beforeModels = snapshotModels(existingModels);
   const result = mergeCursorModelEntries(existingModels, discoveredModels, {
     variants: options.variants === true,
     compact: options.compact === true,
   });
 
   provider.models = result.models;
-  return result;
+  return {
+    syncedCount: result.syncedCount,
+    groupedCount: result.groupedCount,
+    removedCount: result.removedCount,
+    summary: summarizeModelSync(beforeModels, result.models),
+  };
+}
+
+function snapshotModels(models: Record<string, unknown>): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(models));
+}
+
+export function summarizeModelSync(
+  beforeModels: Record<string, unknown>,
+  afterModels: Record<string, unknown>,
+): SyncSummary {
+  let added = 0;
+  let updated = 0;
+  let removed = 0;
+  let skipped = 0;
+
+  for (const [modelId, afterEntry] of Object.entries(afterModels)) {
+    if (!Object.prototype.hasOwnProperty.call(beforeModels, modelId)) {
+      added++;
+      continue;
+    }
+
+    if (JSON.stringify(beforeModels[modelId]) === JSON.stringify(afterEntry)) {
+      skipped++;
+    } else {
+      updated++;
+    }
+  }
+
+  for (const modelId of Object.keys(beforeModels)) {
+    if (!Object.prototype.hasOwnProperty.call(afterModels, modelId)) {
+      removed++;
+    }
+  }
+
+  return {
+    added,
+    updated,
+    removed,
+    priced: countPricedModelEntries(afterModels),
+    skipped,
+  };
+}
+
+function countPricedModelEntries(models: Record<string, unknown>): number {
+  let priced = 0;
+
+  for (const entry of Object.values(models)) {
+    if (!isRecord(entry)) continue;
+    if (isRecord(entry.cost)) priced++;
+
+    if (!isRecord(entry.variants)) continue;
+    for (const variantEntry of Object.values(entry.variants)) {
+      if (isRecord(variantEntry) && isRecord(variantEntry.cost)) {
+        priced++;
+      }
+    }
+  }
+
+  return priced;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function installAiSdk(opencodeDir: string) {
@@ -457,26 +545,26 @@ function commandInstall(options: Options) {
   const copyMode = options.copy === true;
   const pluginSource = resolvePluginSource();
 
-  mkdirSync(opencodeDir, { recursive: true });
-  ensurePluginLink(pluginSource, pluginPath, copyMode);
+  if (!options.dryRun) {
+    mkdirSync(opencodeDir, { recursive: true });
+    ensurePluginLink(pluginSource, pluginPath, copyMode);
+  }
   const config = readConfig(configPath);
   ensureProvider(config, baseUrl);
 
   if (!options.skipModels) {
     const result = syncModelsIntoProvider(config, options);
-    console.log(`Models synced: ${result.syncedCount}`);
-    if (options.variants) {
-      console.log(`Grouped Cursor models: ${result.groupedCount}`);
-    }
-    if (result.removedCount > 0) {
-      console.log(`Raw grouped models removed: ${result.removedCount}`);
-    }
+    printSyncResult(result, options);
   }
 
-  writeConfig(configPath, config, options.noBackup === true);
-  installAiSdk(opencodeDir);
+  if (options.dryRun) {
+    console.log("Dry run: no files changed.");
+  } else {
+    writeConfig(configPath, config, options.noBackup === true);
+    installAiSdk(opencodeDir);
+  }
 
-  console.log(`Installed ${PROVIDER_ID}`);
+  console.log(`${options.dryRun ? "Would install" : "Installed"} ${PROVIDER_ID}`);
   console.log(`Plugin path: ${pluginPath}${copyMode ? " (copy)" : " (symlink)"}`);
   console.log(`Config path: ${configPath}`);
 }
@@ -488,7 +576,18 @@ function commandSyncModels(options: Options) {
 
   const result = syncModelsIntoProvider(config, options);
 
-  writeConfig(configPath, config, options.noBackup === true);
+  if (!options.dryRun) {
+    writeConfig(configPath, config, options.noBackup === true);
+  }
+
+  printSyncResult(result, options);
+  if (options.dryRun) {
+    console.log("Dry run: no changes written.");
+  }
+  console.log(`Config path: ${configPath}`);
+}
+
+function printSyncResult(result: SyncModelsResult, options: Options) {
   console.log(`Models synced: ${result.syncedCount}`);
   if (options.variants) {
     console.log(`Grouped Cursor models: ${result.groupedCount}`);
@@ -496,7 +595,13 @@ function commandSyncModels(options: Options) {
   if (result.removedCount > 0) {
     console.log(`Raw grouped models removed: ${result.removedCount}`);
   }
-  console.log(`Config path: ${configPath}`);
+
+  console.log("Sync summary:");
+  console.log(`  Added: ${result.summary.added}`);
+  console.log(`  Updated: ${result.summary.updated}`);
+  console.log(`  Removed: ${result.summary.removed}`);
+  console.log(`  Priced: ${result.summary.priced}`);
+  console.log(`  Skipped: ${result.summary.skipped}`);
 }
 
 const NPM_PACKAGE = "@rama_nigg/open-cursor";
@@ -692,4 +797,6 @@ function main() {
   }
 }
 
-main();
+if (process.env.NODE_ENV !== "test" && fileURLToPath(import.meta.url) === resolve(process.argv[1] || "")) {
+  main();
+}

--- a/src/models/variants.ts
+++ b/src/models/variants.ts
@@ -56,7 +56,9 @@ const DIRECT_MODEL_IDS = new Set([
 
 const VARIANT_SUFFIXES = [
   "max-thinking-fast",
+  "high-thinking-fast",
   "thinking-high-fast",
+  "medium-thinking",
   "high-thinking",
   "max-thinking",
   "low-fast",
@@ -87,6 +89,33 @@ const DEFAULT_VARIANT_ORDER = [
   "none",
   "xhigh",
   "max",
+];
+
+const VARIANT_DISPLAY_ORDER = [
+  "none",
+  "low",
+  "low-fast",
+  "medium",
+  "medium-fast",
+  "medium-thinking",
+  "high",
+  "high-fast",
+  "high-thinking",
+  "high-thinking-fast",
+  "xhigh",
+  "xhigh-fast",
+  "max",
+  "max-thinking",
+  "max-thinking-fast",
+  "fast",
+  "thinking",
+  "thinking-low",
+  "thinking-medium",
+  "thinking-high",
+  "thinking-high-fast",
+  "thinking-xhigh",
+  "thinking-max",
+  "extra-high",
 ];
 
 function parseVariant(modelId: string): { baseId: string; variant: string } | null {
@@ -130,11 +159,24 @@ function formatModelName(modelId: string): string {
     .join(" ");
 }
 
+function compareVariants(a: CursorModelVariant, b: CursorModelVariant): number {
+  if (a.variant === null) return -1;
+  if (b.variant === null) return 1;
+
+  const aIndex = VARIANT_DISPLAY_ORDER.indexOf(a.variant);
+  const bIndex = VARIANT_DISPLAY_ORDER.indexOf(b.variant);
+
+  if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+  if (aIndex !== -1) return -1;
+  if (bIndex !== -1) return 1;
+  return a.variant.localeCompare(b.variant);
+}
+
 function createGroup(baseId: string, members: CursorModelVariant[]): CursorModelGroup {
   const defaultMember = getDefaultMember(members);
   const variants: Record<string, string> = {};
 
-  for (const member of members) {
+  for (const member of [...members].sort(compareVariants)) {
     if (member.variant) {
       variants[member.variant] = member.cursorModelId;
     }

--- a/src/models/variants.ts
+++ b/src/models/variants.ts
@@ -45,8 +45,6 @@ export type CursorModelMergeResult = {
 
 const DIRECT_MODEL_IDS = new Set([
   "auto",
-  "composer-2-fast",
-  "composer-2",
   "composer-1.5",
   "kimi-k2.5",
   "gemini-3.1-pro",

--- a/src/models/variants.ts
+++ b/src/models/variants.ts
@@ -81,6 +81,10 @@ const VARIANT_SUFFIXES = [
   "fast",
 ];
 
+const QUALIFIED_VARIANT_PREFIXES = [
+  "spark-preview",
+];
+
 const DEFAULT_VARIANT_ORDER = [
   null,
   "medium",
@@ -95,6 +99,7 @@ const VARIANT_DISPLAY_ORDER = [
   "none",
   "low",
   "low-fast",
+  "fast",
   "medium",
   "medium-fast",
   "medium-thinking",
@@ -107,7 +112,6 @@ const VARIANT_DISPLAY_ORDER = [
   "max",
   "max-thinking",
   "max-thinking-fast",
-  "fast",
   "thinking",
   "thinking-low",
   "thinking-medium",
@@ -116,20 +120,69 @@ const VARIANT_DISPLAY_ORDER = [
   "thinking-xhigh",
   "thinking-max",
   "extra-high",
+  "spark-preview",
+  "spark-preview-low",
+  "spark-preview-medium",
+  "spark-preview-high",
+  "spark-preview-xhigh",
 ];
 
-function parseVariant(modelId: string): { baseId: string; variant: string } | null {
+function parseVariant(
+  modelId: string,
+  knownModelIds: Set<string>,
+): { baseId: string; variant: string } | null {
+  const qualifiedVariant = parseQualifiedVariant(modelId, knownModelIds);
+  if (qualifiedVariant) return qualifiedVariant;
+
   for (const variant of VARIANT_SUFFIXES) {
     const suffix = `-${variant}`;
     if (!modelId.endsWith(suffix)) continue;
 
     const baseId = modelId.slice(0, -suffix.length);
     if (isSafeBaseId(baseId)) {
-      return { baseId, variant };
+      return resolveQualifiedBaseVariant(baseId, variant, knownModelIds);
     }
   }
 
   return null;
+}
+
+function parseQualifiedVariant(
+  modelId: string,
+  knownModelIds: Set<string>,
+): { baseId: string; variant: string } | null {
+  for (const qualifier of QUALIFIED_VARIANT_PREFIXES) {
+    const suffix = `-${qualifier}`;
+    if (!modelId.endsWith(suffix)) continue;
+
+    const baseId = modelId.slice(0, -suffix.length);
+    if (knownModelIds.has(baseId) && isSafeBaseId(baseId)) {
+      return { baseId, variant: qualifier };
+    }
+  }
+
+  return null;
+}
+
+function resolveQualifiedBaseVariant(
+  baseId: string,
+  variant: string,
+  knownModelIds: Set<string>,
+): { baseId: string; variant: string } {
+  for (const qualifier of QUALIFIED_VARIANT_PREFIXES) {
+    const suffix = `-${qualifier}`;
+    if (!baseId.endsWith(suffix)) continue;
+
+    const parentBaseId = baseId.slice(0, -suffix.length);
+    if (knownModelIds.has(parentBaseId) && isSafeBaseId(parentBaseId)) {
+      return {
+        baseId: parentBaseId,
+        variant: `${qualifier}-${variant}`,
+      };
+    }
+  }
+
+  return { baseId, variant };
 }
 
 function isSafeBaseId(baseId: string): boolean {
@@ -193,6 +246,7 @@ function createGroup(baseId: string, members: CursorModelVariant[]): CursorModel
 
 export function groupCursorModels(models: DiscoveredCursorModel[]): CursorModelGroups {
   const byId = new Map(models.map(model => [model.id, model]));
+  const knownModelIds = new Set(byId.keys());
   const candidates = new Map<string, CursorModelVariant[]>();
   const direct: DiscoveredCursorModel[] = [];
 
@@ -202,7 +256,7 @@ export function groupCursorModels(models: DiscoveredCursorModel[]): CursorModelG
       continue;
     }
 
-    const parsed = parseVariant(model.id);
+    const parsed = parseVariant(model.id, knownModelIds);
     if (!parsed) {
       continue;
     }

--- a/src/models/variants.ts
+++ b/src/models/variants.ts
@@ -1,0 +1,295 @@
+export type DiscoveredCursorModel = {
+  id: string;
+  name: string;
+};
+
+export type CursorModelVariant = {
+  baseId: string;
+  variant: string | null;
+  cursorModelId: string;
+  name: string;
+};
+
+export type CursorModelGroup = {
+  baseId: string;
+  name: string;
+  defaultCursorModelId: string;
+  variants: Record<string, string>;
+  members: CursorModelVariant[];
+};
+
+export type CursorModelGroups = {
+  groups: CursorModelGroup[];
+  direct: DiscoveredCursorModel[];
+};
+
+export type OpenCodeCursorModelEntry = {
+  name: string;
+  options?: {
+    cursorModel: string;
+  };
+  variants?: Record<string, { cursorModel: string }>;
+};
+
+export type CursorModelMergeOptions = {
+  variants: boolean;
+  compact: boolean;
+};
+
+export type CursorModelMergeResult = {
+  models: Record<string, unknown>;
+  syncedCount: number;
+  groupedCount: number;
+  removedCount: number;
+};
+
+const DIRECT_MODEL_IDS = new Set([
+  "auto",
+  "composer-2-fast",
+  "composer-2",
+  "composer-1.5",
+  "kimi-k2.5",
+  "gemini-3.1-pro",
+  "gemini-3-flash",
+  "gpt-5-mini",
+]);
+
+const VARIANT_SUFFIXES = [
+  "max-thinking-fast",
+  "thinking-high-fast",
+  "high-thinking",
+  "max-thinking",
+  "low-fast",
+  "medium-fast",
+  "high-fast",
+  "xhigh-fast",
+  "thinking-low",
+  "thinking-medium",
+  "thinking-high",
+  "thinking-xhigh",
+  "thinking-max",
+  "extra-high",
+  "thinking",
+  "none",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+  "fast",
+];
+
+const DEFAULT_VARIANT_ORDER = [
+  null,
+  "medium",
+  "high",
+  "low",
+  "none",
+  "xhigh",
+  "max",
+];
+
+function parseVariant(modelId: string): { baseId: string; variant: string } | null {
+  for (const variant of VARIANT_SUFFIXES) {
+    const suffix = `-${variant}`;
+    if (!modelId.endsWith(suffix)) continue;
+
+    const baseId = modelId.slice(0, -suffix.length);
+    if (isSafeBaseId(baseId)) {
+      return { baseId, variant };
+    }
+  }
+
+  return null;
+}
+
+function isSafeBaseId(baseId: string): boolean {
+  const parts = baseId.split("-").filter(Boolean);
+  if (parts.length < 2) return false;
+  if (baseId === "gpt-5") return false;
+  return true;
+}
+
+function getDefaultMember(members: CursorModelVariant[]): CursorModelVariant {
+  for (const variant of DEFAULT_VARIANT_ORDER) {
+    const member = members.find(candidate => candidate.variant === variant);
+    if (member) return member;
+  }
+
+  return members[0];
+}
+
+function formatModelName(modelId: string): string {
+  return modelId
+    .split("-")
+    .map(part => {
+      if (part === "gpt") return "GPT";
+      if (part === "xhigh") return "XHigh";
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(" ");
+}
+
+function createGroup(baseId: string, members: CursorModelVariant[]): CursorModelGroup {
+  const defaultMember = getDefaultMember(members);
+  const variants: Record<string, string> = {};
+
+  for (const member of members) {
+    if (member.variant) {
+      variants[member.variant] = member.cursorModelId;
+    }
+  }
+
+  return {
+    baseId,
+    name: defaultMember.variant === null ? defaultMember.name : formatModelName(baseId),
+    defaultCursorModelId: defaultMember.cursorModelId,
+    variants,
+    members,
+  };
+}
+
+export function groupCursorModels(models: DiscoveredCursorModel[]): CursorModelGroups {
+  const byId = new Map(models.map(model => [model.id, model]));
+  const candidates = new Map<string, CursorModelVariant[]>();
+  const direct: DiscoveredCursorModel[] = [];
+
+  for (const model of models) {
+    if (DIRECT_MODEL_IDS.has(model.id)) {
+      direct.push(model);
+      continue;
+    }
+
+    const parsed = parseVariant(model.id);
+    if (!parsed) {
+      continue;
+    }
+
+    const members = candidates.get(parsed.baseId) || [];
+    members.push({
+      baseId: parsed.baseId,
+      variant: parsed.variant,
+      cursorModelId: model.id,
+      name: model.name,
+    });
+    candidates.set(parsed.baseId, members);
+  }
+
+  for (const model of models) {
+    if (DIRECT_MODEL_IDS.has(model.id)) continue;
+    if (!candidates.has(model.id)) continue;
+
+    candidates.get(model.id)?.push({
+      baseId: model.id,
+      variant: null,
+      cursorModelId: model.id,
+      name: model.name,
+    });
+  }
+
+  const groupedIds = new Set<string>();
+  const groups: CursorModelGroup[] = [];
+
+  for (const [baseId, members] of candidates) {
+    if (members.length < 2 && !byId.has(baseId)) continue;
+
+    groups.push(createGroup(baseId, members));
+    for (const member of members) {
+      groupedIds.add(member.cursorModelId);
+    }
+  }
+
+  for (const model of models) {
+    if (groupedIds.has(model.id)) continue;
+    if (direct.some(candidate => candidate.id === model.id)) continue;
+    direct.push(model);
+  }
+
+  return { groups, direct };
+}
+
+export function createVariantModelEntries(models: DiscoveredCursorModel[]): {
+  entries: Record<string, OpenCodeCursorModelEntry>;
+  groupedModelIds: Set<string>;
+} {
+  const { groups, direct } = groupCursorModels(models);
+  const entries: Record<string, OpenCodeCursorModelEntry> = {};
+  const groupedModelIds = new Set<string>();
+
+  for (const group of groups) {
+    const variants: Record<string, { cursorModel: string }> = {};
+    for (const [variant, cursorModel] of Object.entries(group.variants)) {
+      variants[variant] = { cursorModel };
+    }
+
+    entries[group.baseId] = {
+      name: group.name,
+      options: {
+        cursorModel: group.defaultCursorModelId,
+      },
+      variants,
+    };
+
+    for (const member of group.members) {
+      groupedModelIds.add(member.cursorModelId);
+    }
+  }
+
+  for (const model of direct) {
+    entries[model.id] = { name: model.name };
+  }
+
+  return { entries, groupedModelIds };
+}
+
+export function mergeCursorModelEntries(
+  existingModels: Record<string, unknown>,
+  discoveredModels: DiscoveredCursorModel[],
+  options: CursorModelMergeOptions,
+): CursorModelMergeResult {
+  if (!options.variants) {
+    return mergeDirectModelEntries(existingModels, discoveredModels);
+  }
+
+  const { entries, groupedModelIds } = createVariantModelEntries(discoveredModels);
+  const models = { ...existingModels };
+  let removedCount = 0;
+
+  if (options.compact) {
+    for (const modelId of groupedModelIds) {
+      if (!Object.prototype.hasOwnProperty.call(models, modelId)) continue;
+      if (Object.prototype.hasOwnProperty.call(entries, modelId)) continue;
+      delete models[modelId];
+      removedCount++;
+    }
+  }
+
+  for (const [modelId, entry] of Object.entries(entries)) {
+    models[modelId] = entry;
+  }
+
+  return {
+    models,
+    syncedCount: Object.keys(entries).length,
+    groupedCount: groupedModelIds.size,
+    removedCount,
+  };
+}
+
+function mergeDirectModelEntries(
+  existingModels: Record<string, unknown>,
+  discoveredModels: DiscoveredCursorModel[],
+): CursorModelMergeResult {
+  const models = { ...existingModels };
+
+  for (const model of discoveredModels) {
+    models[model.id] = { name: model.name };
+  }
+
+  return {
+    models,
+    syncedCount: discoveredModels.length,
+    groupedCount: 0,
+    removedCount: 0,
+  };
+}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -621,6 +621,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
       // DEBUG: Log raw request structure for tool-loop investigation
       debugLogToFile("raw_request_body", {
         model: body?.model,
+        cursorModel: body?.cursorModel,
         stream,
         toolCount: tools.length,
         toolNames: tools.map((t: any) => t?.function?.name ?? t?.name ?? "unknown"),
@@ -637,8 +638,8 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
       const subagentNames = readSubagentNames();
       const prompt = buildPromptFromMessages(messages, tools, subagentNames);
-      const model = boundaryContext.run("normalizeRuntimeModel", (boundary) =>
-        boundary.normalizeRuntimeModel(body?.model),
+      const model = boundaryContext.run("resolveRuntimeModel", (boundary) =>
+        boundary.resolveRuntimeModel(body?.model, body?.cursorModel),
       );
       const msgSummaryBun = messages.map((m: any, i: number) => {
         const role = m?.role ?? "?";
@@ -1102,8 +1103,8 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
       const subagentNames = readSubagentNames();
       const prompt = buildPromptFromMessages(messages, tools, subagentNames);
-      const model = boundaryContext.run("normalizeRuntimeModel", (boundary) =>
-        boundary.normalizeRuntimeModel(bodyData?.model),
+      const model = boundaryContext.run("resolveRuntimeModel", (boundary) =>
+        boundary.resolveRuntimeModel(bodyData?.model, bodyData?.cursorModel),
       );
       const msgSummary = messages.map((m: any, i: number) => {
         const role = m?.role ?? "?";

--- a/src/provider/boundary.ts
+++ b/src/provider/boundary.ts
@@ -36,6 +36,7 @@ export interface ProviderBoundary {
   ): ToolLoopFlags;
   matchesProvider(inputModel: any): boolean;
   normalizeRuntimeModel(model: unknown): string;
+  resolveRuntimeModel(model: unknown, cursorModel: unknown): string;
   applyChatParamDefaults(
     output: any,
     proxyBaseURL: string | undefined,
@@ -135,6 +136,15 @@ function createSharedBoundary(
       }
 
       return raw;
+    },
+
+    resolveRuntimeModel(model, cursorModel) {
+      const rawCursorModel = typeof cursorModel === "string" ? cursorModel.trim() : "";
+      if (rawCursorModel.length > 0) {
+        return this.normalizeRuntimeModel(rawCursorModel);
+      }
+
+      return this.normalizeRuntimeModel(model);
     },
 
     applyChatParamDefaults(output, proxyBaseURL, defaultBaseURL, defaultApiKey) {

--- a/tests/unit/cli/opencode-cursor.test.ts
+++ b/tests/unit/cli/opencode-cursor.test.ts
@@ -7,6 +7,7 @@ import {
   checkCursorAgentLogin,
   runDoctorChecks,
   getStatusResult,
+  explainCursorModels,
   summarizeModelSync,
 } from "../../../src/cli/opencode-cursor.js";
 
@@ -48,7 +49,7 @@ describe("cli/opencode-cursor commandDoctor", () => {
     const results = runDoctorChecks("/tmp/test-config.json", "/tmp/test-plugin");
     expect(results.length).toBeGreaterThan(5);
     expect(results.every(r => typeof r.passed === "boolean")).toBe(true);
-  });
+  }, 10000);
 });
 
 describe("cli/opencode-cursor status", () => {
@@ -86,5 +87,32 @@ describe("cli/opencode-cursor sync summary", () => {
       priced: 2,
       skipped: 1,
     });
+  });
+});
+
+describe("cli/opencode-cursor model explanation", () => {
+  it("explains compact model groups and direct models", () => {
+    const explanation = explainCursorModels([
+      { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+      { id: "gpt-5.3-codex-low", name: "GPT-5.3 Codex Low" },
+      { id: "gpt-5.3-codex-high", name: "GPT-5.3 Codex High" },
+      { id: "auto", name: "Auto" },
+    ]);
+
+    expect(explanation.modelCount).toBe(4);
+    expect(explanation.groupedCount).toBe(3);
+    expect(explanation.direct).toEqual(["auto"]);
+    expect(explanation.groups).toEqual([
+      {
+        id: "gpt-5.3-codex",
+        name: "GPT-5.3 Codex",
+        defaultCursorModel: "gpt-5.3-codex",
+        memberCount: 3,
+        variants: {
+          low: "gpt-5.3-codex-low",
+          high: "gpt-5.3-codex-high",
+        },
+      },
+    ]);
   });
 });

--- a/tests/unit/cli/opencode-cursor.test.ts
+++ b/tests/unit/cli/opencode-cursor.test.ts
@@ -7,6 +7,7 @@ import {
   checkCursorAgentLogin,
   runDoctorChecks,
   getStatusResult,
+  summarizeModelSync,
 } from "../../../src/cli/opencode-cursor.js";
 
 describe("cli/opencode-cursor branding", () => {
@@ -56,5 +57,34 @@ describe("cli/opencode-cursor status", () => {
     expect(result).toHaveProperty("plugin");
     expect(result).toHaveProperty("provider");
     expect(result).toHaveProperty("aiSdk");
+  });
+});
+
+describe("cli/opencode-cursor sync summary", () => {
+  it("reports added, updated, removed, priced, and skipped entries", () => {
+    const before = {
+      unchanged: { name: "Unchanged" },
+      changed: { name: "Old" },
+      removed: { name: "Removed" },
+    };
+    const after = {
+      unchanged: { name: "Unchanged" },
+      changed: { name: "New" },
+      added: { name: "Added", cost: { input: 1, output: 2 } },
+      variants: {
+        name: "Variants",
+        variants: {
+          high: { cursorModel: "variants-high", cost: { input: 1, output: 2 } },
+        },
+      },
+    };
+
+    expect(summarizeModelSync(before, after)).toEqual({
+      added: 2,
+      updated: 1,
+      removed: 1,
+      priced: 2,
+      skipped: 1,
+    });
   });
 });

--- a/tests/unit/models/variants.test.ts
+++ b/tests/unit/models/variants.test.ts
@@ -70,6 +70,33 @@ describe("models/variants", () => {
     });
   });
 
+  it("folds spark preview models into the parent family when the parent exists", () => {
+    const result = groupCursorModels([
+      { id: "gpt-5.3-codex-low", name: "GPT-5.3 Codex Low" },
+      { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+      { id: "gpt-5.3-codex-high", name: "GPT-5.3 Codex High" },
+      { id: "gpt-5.3-codex-spark-preview-low", name: "GPT-5.3 Codex Spark Preview Low" },
+      { id: "gpt-5.3-codex-spark-preview", name: "GPT-5.3 Codex Spark Preview" },
+      { id: "gpt-5.3-codex-spark-preview-high", name: "GPT-5.3 Codex Spark Preview High" },
+      { id: "gpt-5.3-codex-spark-preview-xhigh", name: "GPT-5.3 Codex Spark Preview XHigh" },
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.direct).toEqual([]);
+    expect(result.groups[0]).toMatchObject({
+      baseId: "gpt-5.3-codex",
+      defaultCursorModelId: "gpt-5.3-codex",
+      variants: {
+        low: "gpt-5.3-codex-low",
+        high: "gpt-5.3-codex-high",
+        "spark-preview": "gpt-5.3-codex-spark-preview",
+        "spark-preview-low": "gpt-5.3-codex-spark-preview-low",
+        "spark-preview-high": "gpt-5.3-codex-spark-preview-high",
+        "spark-preview-xhigh": "gpt-5.3-codex-spark-preview-xhigh",
+      },
+    });
+  });
+
   it("groups thinking variants under the non-thinking family", () => {
     const result = groupCursorModels([
       { id: "claude-opus-4-7-low", name: "Claude Opus 4.7 Low" },

--- a/tests/unit/models/variants.test.ts
+++ b/tests/unit/models/variants.test.ts
@@ -33,7 +33,7 @@ describe("models/variants", () => {
   it("keeps ambiguous product models direct", () => {
     const result = groupCursorModels([
       { id: "auto", name: "Auto" },
-      { id: "composer-2-fast", name: "Composer 2 Fast" },
+      { id: "composer-1.5", name: "Composer 1.5" },
       { id: "gemini-3-flash", name: "Gemini 3 Flash" },
       { id: "gpt-5-mini", name: "GPT-5 Mini" },
       { id: "kimi-k2.5", name: "Kimi K2.5" },
@@ -42,11 +42,30 @@ describe("models/variants", () => {
     expect(result.groups).toEqual([]);
     expect(result.direct.map(model => model.id)).toEqual([
       "auto",
-      "composer-2-fast",
+      "composer-1.5",
       "gemini-3-flash",
       "gpt-5-mini",
       "kimi-k2.5",
     ]);
+  });
+
+  it("groups Composer 2 fast under Composer 2 when the base exists", () => {
+    const result = groupCursorModels([
+      { id: "composer-2", name: "Composer 2" },
+      { id: "composer-2-fast", name: "Composer 2 Fast" },
+      { id: "composer-1.5", name: "Composer 1.5" },
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      baseId: "composer-2",
+      name: "Composer 2",
+      defaultCursorModelId: "composer-2",
+      variants: {
+        fast: "composer-2-fast",
+      },
+    });
+    expect(result.direct.map(model => model.id)).toEqual(["composer-1.5"]);
   });
 
   it("uses conservative base names for mini, nano, and preview families", () => {

--- a/tests/unit/models/variants.test.ts
+++ b/tests/unit/models/variants.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "bun:test";
+import {
+  createVariantModelEntries,
+  groupCursorModels,
+  mergeCursorModelEntries,
+} from "../../../src/models/variants.js";
+
+describe("models/variants", () => {
+  it("groups Cursor model families into base models and variants", () => {
+    const result = groupCursorModels([
+      { id: "gpt-5.3-codex-low", name: "GPT-5.3 Codex Low" },
+      { id: "gpt-5.3-codex-low-fast", name: "GPT-5.3 Codex Low Fast" },
+      { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+      { id: "gpt-5.3-codex-high", name: "GPT-5.3 Codex High" },
+      { id: "gpt-5.3-codex-high-fast", name: "GPT-5.3 Codex High Fast" },
+    ]);
+
+    expect(result.direct).toEqual([]);
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      baseId: "gpt-5.3-codex",
+      name: "GPT-5.3 Codex",
+      defaultCursorModelId: "gpt-5.3-codex",
+      variants: {
+        low: "gpt-5.3-codex-low",
+        "low-fast": "gpt-5.3-codex-low-fast",
+        high: "gpt-5.3-codex-high",
+        "high-fast": "gpt-5.3-codex-high-fast",
+      },
+    });
+  });
+
+  it("keeps ambiguous product models direct", () => {
+    const result = groupCursorModels([
+      { id: "auto", name: "Auto" },
+      { id: "composer-2-fast", name: "Composer 2 Fast" },
+      { id: "gemini-3-flash", name: "Gemini 3 Flash" },
+      { id: "gpt-5-mini", name: "GPT-5 Mini" },
+      { id: "kimi-k2.5", name: "Kimi K2.5" },
+    ]);
+
+    expect(result.groups).toEqual([]);
+    expect(result.direct.map(model => model.id)).toEqual([
+      "auto",
+      "composer-2-fast",
+      "gemini-3-flash",
+      "gpt-5-mini",
+      "kimi-k2.5",
+    ]);
+  });
+
+  it("uses conservative base names for mini, nano, and preview families", () => {
+    const result = groupCursorModels([
+      { id: "gpt-5.4-mini-none", name: "GPT-5.4 Mini None" },
+      { id: "gpt-5.4-mini-low", name: "GPT-5.4 Mini Low" },
+      { id: "gpt-5.4-nano-medium", name: "GPT-5.4 Nano Medium" },
+      { id: "gpt-5.4-nano-high", name: "GPT-5.4 Nano High" },
+      { id: "gpt-5.3-codex-spark-preview-low", name: "GPT-5.3 Codex Spark Preview Low" },
+      { id: "gpt-5.3-codex-spark-preview-high", name: "GPT-5.3 Codex Spark Preview High" },
+    ]);
+
+    expect(result.groups.map(group => group.baseId)).toEqual([
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+      "gpt-5.3-codex-spark-preview",
+    ]);
+    expect(result.groups[0].variants).toEqual({
+      none: "gpt-5.4-mini-none",
+      low: "gpt-5.4-mini-low",
+    });
+  });
+
+  it("groups thinking variants under the non-thinking family", () => {
+    const result = groupCursorModels([
+      { id: "claude-opus-4-7-low", name: "Claude Opus 4.7 Low" },
+      { id: "claude-opus-4-7-thinking-high", name: "Claude Opus 4.7 Thinking High" },
+      { id: "claude-opus-4-7-thinking-high-fast", name: "Claude Opus 4.7 Thinking High Fast" },
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      baseId: "claude-opus-4-7",
+      variants: {
+        low: "claude-opus-4-7-low",
+        "thinking-high": "claude-opus-4-7-thinking-high",
+        "thinking-high-fast": "claude-opus-4-7-thinking-high-fast",
+      },
+    });
+  });
+
+  it("creates OpenCode model entries with cursorModel options and variants", () => {
+    const { entries } = createVariantModelEntries([
+      { id: "gpt-5.5-medium", name: "GPT-5.5 Medium" },
+      { id: "gpt-5.5-high", name: "GPT-5.5 High" },
+      { id: "gpt-5.5-extra-high", name: "GPT-5.5 Extra High" },
+    ]);
+
+    expect(entries).toEqual({
+      "gpt-5.5": {
+        name: "GPT 5.5",
+        options: {
+          cursorModel: "gpt-5.5-medium",
+        },
+        variants: {
+          medium: { cursorModel: "gpt-5.5-medium" },
+          high: { cursorModel: "gpt-5.5-high" },
+          "extra-high": { cursorModel: "gpt-5.5-extra-high" },
+        },
+      },
+    });
+  });
+
+  it("merges compact variant entries while preserving custom models", () => {
+    const result = mergeCursorModelEntries(
+      {
+        "custom-model": { name: "Custom" },
+        "gpt-5.3-codex-low": { name: "Old Low" },
+        "gpt-5.3-codex-high": { name: "Old High" },
+      },
+      [
+        { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+        { id: "gpt-5.3-codex-low", name: "GPT-5.3 Codex Low" },
+        { id: "gpt-5.3-codex-high", name: "GPT-5.3 Codex High" },
+      ],
+      { variants: true, compact: true },
+    );
+
+    expect(result.removedCount).toBe(2);
+    expect(result.models).toEqual({
+      "custom-model": { name: "Custom" },
+      "gpt-5.3-codex": {
+        name: "GPT-5.3 Codex",
+        options: {
+          cursorModel: "gpt-5.3-codex",
+        },
+        variants: {
+          low: { cursorModel: "gpt-5.3-codex-low" },
+          high: { cursorModel: "gpt-5.3-codex-high" },
+        },
+      },
+    });
+  });
+
+  it("keeps default direct sync behavior unchanged", () => {
+    const result = mergeCursorModelEntries(
+      {
+        "custom-model": { name: "Custom" },
+      },
+      [
+        { id: "gpt-5.3-codex-low", name: "GPT-5.3 Codex Low" },
+        { id: "gpt-5.3-codex-high", name: "GPT-5.3 Codex High" },
+      ],
+      { variants: false, compact: false },
+    );
+
+    expect(result).toEqual({
+      syncedCount: 2,
+      groupedCount: 0,
+      removedCount: 0,
+      models: {
+        "custom-model": { name: "Custom" },
+        "gpt-5.3-codex-low": { name: "GPT-5.3 Codex Low" },
+        "gpt-5.3-codex-high": { name: "GPT-5.3 Codex High" },
+      },
+    });
+  });
+
+  it("keeps raw grouped entries unless compact mode is enabled", () => {
+    const result = mergeCursorModelEntries(
+      {
+        "gpt-5.3-codex-low": { name: "Old Low" },
+        "gpt-5.3-codex-high": { name: "Old High" },
+      },
+      [
+        { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+        { id: "gpt-5.3-codex-low", name: "GPT-5.3 Codex Low" },
+        { id: "gpt-5.3-codex-high", name: "GPT-5.3 Codex High" },
+      ],
+      { variants: true, compact: false },
+    );
+
+    expect(result.removedCount).toBe(0);
+    expect(result.models["gpt-5.3-codex-low"]).toEqual({ name: "Old Low" });
+    expect(result.models["gpt-5.3-codex-high"]).toEqual({ name: "Old High" });
+    expect(result.models["gpt-5.3-codex"]).toEqual({
+      name: "GPT-5.3 Codex",
+      options: {
+        cursorModel: "gpt-5.3-codex",
+      },
+      variants: {
+        low: { cursorModel: "gpt-5.3-codex-low" },
+        high: { cursorModel: "gpt-5.3-codex-high" },
+      },
+    });
+  });
+});

--- a/tests/unit/models/variants.test.ts
+++ b/tests/unit/models/variants.test.ts
@@ -88,6 +88,48 @@ describe("models/variants", () => {
     });
   });
 
+  it("groups Claude 4.6 Opus thinking variants under one family", () => {
+    const result = groupCursorModels([
+      { id: "claude-4.6-opus-high", name: "Opus 4.6 1M" },
+      { id: "claude-4.6-opus-max", name: "Opus 4.6 1M Max" },
+      { id: "claude-4.6-opus-high-thinking", name: "Opus 4.6 1M Thinking" },
+      { id: "claude-4.6-opus-high-thinking-fast", name: "Opus 4.6 1M Thinking Fast" },
+      { id: "claude-4.6-opus-max-thinking", name: "Opus 4.6 1M Max Thinking" },
+      { id: "claude-4.6-opus-max-thinking-fast", name: "Opus 4.6 1M Max Thinking Fast" },
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      baseId: "claude-4.6-opus",
+      defaultCursorModelId: "claude-4.6-opus-high",
+      variants: {
+        high: "claude-4.6-opus-high",
+        max: "claude-4.6-opus-max",
+        "high-thinking": "claude-4.6-opus-high-thinking",
+        "high-thinking-fast": "claude-4.6-opus-high-thinking-fast",
+        "max-thinking": "claude-4.6-opus-max-thinking",
+        "max-thinking-fast": "claude-4.6-opus-max-thinking-fast",
+      },
+    });
+  });
+
+  it("groups Claude 4.6 Sonnet thinking variants under one family", () => {
+    const result = groupCursorModels([
+      { id: "claude-4.6-sonnet-medium", name: "Sonnet 4.6 1M" },
+      { id: "claude-4.6-sonnet-medium-thinking", name: "Sonnet 4.6 1M Thinking" },
+    ]);
+
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0]).toMatchObject({
+      baseId: "claude-4.6-sonnet",
+      defaultCursorModelId: "claude-4.6-sonnet-medium",
+      variants: {
+        medium: "claude-4.6-sonnet-medium",
+        "medium-thinking": "claude-4.6-sonnet-medium-thinking",
+      },
+    });
+  });
+
   it("creates OpenCode model entries with cursorModel options and variants", () => {
     const { entries } = createVariantModelEntries([
       { id: "gpt-5.5-medium", name: "GPT-5.5 Medium" },

--- a/tests/unit/provider-boundary.test.ts
+++ b/tests/unit/provider-boundary.test.ts
@@ -67,6 +67,24 @@ describe("provider boundary", () => {
     expect(boundary.normalizeRuntimeModel("   ")).toBe("auto");
   });
 
+  it("prefers merged cursorModel when resolving runtime models", () => {
+    const boundary = createProviderBoundary("v1", "cursor-acp");
+
+    expect(
+      boundary.resolveRuntimeModel("cursor-acp/gpt-5.3-codex", "gpt-5.3-codex-high"),
+    ).toBe("gpt-5.3-codex-high");
+    expect(
+      boundary.resolveRuntimeModel("cursor-acp/gpt-5.3-codex", "cursor-acp/gpt-5.3-codex-high-fast"),
+    ).toBe("gpt-5.3-codex-high-fast");
+    expect(
+      boundary.resolveRuntimeModel("cursor-acp/gpt-5.3-codex", "   "),
+    ).toBe("gpt-5.3-codex");
+    expect(
+      boundary.resolveRuntimeModel("cursor-acp/gpt-5.3-codex", undefined),
+    ).toBe("gpt-5.3-codex");
+    expect(boundary.resolveRuntimeModel(undefined, undefined)).toBe("auto");
+  });
+
   it("matches provider across providerID/providerId/provider keys", () => {
     const boundary = createProviderBoundary("v1", "cursor-acp");
     expect(boundary.matchesProvider({ providerID: "cursor-acp" })).toBe(true);


### PR DESCRIPTION
## Summary
- prefer the merged  request field when selecting the  value
- keep the existing  normalization as the fallback path
- document runtime variant resolution in the architecture notes

## Testing
- bun test v1.3.12 (700fc117)
- bun test v1.3.12 (700fc117)
- Bundled 199 modules in 15ms

  index.js               0.63 MB   (entry point)
  plugin-entry.js        0.61 MB   (entry point)
  cli/discover.js        8.49 KB   (entry point)
  cli/opencode-cursor.js  25.28 KB  (entry point)
  cli/mcptool.js         0.37 MB   (entry point)

## Notes
This is the first small runtime PR for Cursor model variants. It does not add automatic variant grouping or ; those can follow in a separate PR.