### PR TITLE
fix: prevent edit tool from silently overwriting files when 

### DIFF
--- a/src/provider/runtime-interception.ts
+++ b/src/provider/runtime-interception.ts
@@ -815,45 +815,11 @@ function tryRerouteEditToWrite(
   allowedToolNames: Set<string>,
   toolSchemaMap: Map<string, unknown>,
 ): { path: string; toolCall: OpenAiToolCall } | null {
-  if (toolCall.function.name.toLowerCase() !== "edit") {
-    return null;
-  }
-  if (!allowedToolNames.has("write") || !toolSchemaMap.has("write")) {
-    return null;
-  }
-
-  const path = typeof normalizedArgs.path === "string" && normalizedArgs.path.length > 0
-    ? normalizedArgs.path
-    : null;
-  if (!path) {
-    return null;
-  }
-
-  const content =
-    typeof normalizedArgs.new_string === "string"
-      ? normalizedArgs.new_string
-      : typeof normalizedArgs.content === "string"
-        ? normalizedArgs.content
-        : null;
-  if (content === null) {
-    return null;
-  }
-
-  const oldString = normalizedArgs.old_string;
-  if (typeof oldString === "string" && oldString.length > 0) {
-    return null;
-  }
-
-  return {
-    path,
-    toolCall: {
-      ...toolCall,
-      function: {
-        name: "write",
-        arguments: JSON.stringify({ path, content }),
-      },
-    },
-  };
+  // NOTE: Do NOT reroute edit to write based on empty old_string.
+  // OpenCode's edit tool interprets oldString === "" as "overwrite entire file",
+  // and rerouting to write also overwrites. Both are catastrophic.
+  // Let schema validation fail and return an error to the model instead.
+  return null;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/provider/tool-schema-compat.ts
+++ b/src/provider/tool-schema-compat.ts
@@ -261,8 +261,14 @@ function normalizeToolSpecificArgs(toolName: string, args: JsonRecord): JsonReco
   if (!hasStringNew && typeof content === "string") {
     repaired.new_string = content;
   }
-  if (typeof repaired.new_string === "string" && !hasStringOld) {
-    repaired.old_string = "";
+  // NOTE: Do NOT default old_string to "" here. OpenCode's edit tool interprets
+  // oldString === "" as "overwrite entire file with newString", which is catastrophic.
+  // If old_string is truly missing, let schema validation fail and the caller
+  // will reroute to write or return an error — never silently destroy a file.
+  // If old_string is explicitly sent as "", this is likely a confused model call —
+  // delete it so schema validation properly fails rather than silently destroying.
+  if (hasStringOld && repaired.old_string === "") {
+    delete repaired.old_string;
   }
 
   return repaired;


### PR DESCRIPTION
old_string is empty

When Claude (or any model) sends an edit tool call with old_string set to an empty string, OpenCode's edit tool interprets this as "overwrite the entire file with new_string", silently destroying file contents.

This fix:

1. tool-schema-compat.ts: Do NOT default old_string to "" when missing. If a model sends old_string="", delete it so schema validation properly fails with an error message directing the model to use 'write' instead.

2. runtime-interception.ts: tryRerouteEditToWrite() now returns null immediately. Previously it would reroute empty-old_string edits to the 'write' tool, which also overwrites the entire file - just as catastrophic.

The root cause was two-fold:
- Models sometimes emit edit calls with old_string="" (likely confusion with write tool semantics)
- The compat layer would add old_string="" for missing values
- OpenCode's edit tool treats oldString==="" as "replace entire file"

Now malformed edit calls fail validation and the model receives guidance: "Use write for full-file replacement, or provide path, old_string, and new_string for edit."