### PR TITLE
fix: reroute malformed full-file edit to write in OpenCode tool loop

### DIFF
--- a/src/provider/runtime-interception.ts
+++ b/src/provider/runtime-interception.ts
@@ -3,7 +3,11 @@ import { extractOpenAiToolCall, type OpenAiToolCall, type ToolCallExtractionResu
 import type { StreamJsonToolCallEvent } from "../streaming/types.js";
 import type { ToolRouter } from "../tools/router.js";
 import { createLogger } from "../utils/logger.js";
-import { applyToolSchemaCompat, type ToolSchemaValidationResult } from "./tool-schema-compat.js";
+import {
+  applyToolSchemaCompat,
+  tryRerouteEditToWrite,
+  type ToolSchemaValidationResult,
+} from "./tool-schema-compat.js";
 import type { ToolLoopGuard } from "./tool-loop-guard.js";
 import type { ProviderBoundaryMode, ToolLoopMode } from "./boundary.js";
 import type { ProviderBoundary } from "./boundary.js";
@@ -188,6 +192,20 @@ export async function handleToolLoopEventLegacy(
           return { intercepted: false, skipConverter: true };
         }
         return { intercepted: false, skipConverter: true, terminate: validationTermination };
+      }
+
+      const reroutedWrite = tryRerouteEditToWrite(
+        normalizedToolCall,
+        compat,
+        allowedToolNames,
+        toolSchemaMap,
+      );
+      if (reroutedWrite) {
+        log.debug("Rerouting malformed edit call to write (legacy)", {
+          missing: compat.validation.missing,
+        });
+        await onInterceptedToolCall(reroutedWrite);
+        return { intercepted: true, skipConverter: true };
       }
 
       if (shouldEmitNonFatalSchemaValidationHint(normalizedToolCall, compat.validation)) {
@@ -381,6 +399,23 @@ export async function handleToolLoopEventV1(
         intercepted: false,
         skipConverter: true,
         terminate: createSchemaValidationTermination(normalizedToolCall, compat.validation),
+      };
+    }
+    const reroutedWrite = tryRerouteEditToWrite(
+      normalizedToolCall,
+      compat,
+      allowedToolNames,
+      toolSchemaMap,
+    );
+    if (reroutedWrite) {
+      log.debug("Rerouting malformed edit call to write", {
+        missing: compat.validation.missing,
+        typeErrors: compat.validation.typeErrors,
+      });
+      await onInterceptedToolCall(reroutedWrite);
+      return {
+        intercepted: true,
+        skipConverter: true,
       };
     }
     if (
@@ -668,11 +703,11 @@ function createNonFatalSchemaValidationHintChunk(
   validation: ToolSchemaValidationResult,
 ): NonFatalSchemaValidationResultChunk {
   const termination = createSchemaValidationTermination(toolCall, validation);
-  const hint =
-    termination.repairHint
-    || "Use write for full-file replacement, or provide path, old_string, and new_string for edit.";
+  const fallbackHint =
+    "Use write for full-file replacement, or provide path, old_string, and new_string for edit.";
+  const suffix = termination.repairHint ? "" : ` ${fallbackHint}`;
   const content =
-    `Skipped malformed tool call "${toolCall.function.name}": ${termination.message} ${hint}`.trim();
+    `Skipped malformed tool call "${toolCall.function.name}": ${termination.message}${suffix}`.trim();
   return {
     id: meta.id,
     object: "chat.completion.chunk",

--- a/src/provider/tool-schema-compat.ts
+++ b/src/provider/tool-schema-compat.ts
@@ -242,6 +242,8 @@ function normalizeToolSpecificArgs(toolName: string, args: JsonRecord): JsonReco
     return args;
   }
 
+  const hadOldStringProperty = hasOwn(args, "old_string");
+
   const repaired: JsonRecord = { ...args };
   const hasStringNew = typeof repaired.new_string === "string";
   const hasStringOld = typeof repaired.old_string === "string";
@@ -263,6 +265,19 @@ function normalizeToolSpecificArgs(toolName: string, args: JsonRecord): JsonReco
   }
   if (hasStringOld && repaired.old_string === "") {
     delete repaired.old_string;
+  }
+
+  // Executor (`resolveEditArguments`) treats missing old_string + new bodies as full-file
+  // replace. Schema requires old_string unless we synthesize empty here. Do not synthesize when
+  // the model explicitly sent old_string (including ""); those are stripped above on purpose.
+  if (
+    !hadOldStringProperty
+    && typeof repaired.path === "string"
+    && repaired.path.trim().length > 0
+    && typeof repaired.new_string === "string"
+    && repaired.old_string === undefined
+  ) {
+    repaired.old_string = "";
   }
 
   return repaired;

--- a/src/provider/tool-schema-compat.ts
+++ b/src/provider/tool-schema-compat.ts
@@ -49,6 +49,7 @@ export interface ToolSchemaValidationResult {
 export interface ToolSchemaCompatResult {
   toolCall: OpenAiToolCall;
   normalizedArgs: JsonRecord;
+  originalArgs: JsonRecord;
   originalArgKeys: string[];
   normalizedArgKeys: string[];
   collisionKeys: string[];
@@ -89,6 +90,10 @@ export function applyToolSchemaCompat(
     sanitization.args,
     schema,
     sanitization.unexpected,
+    {
+      originalArgs: parsedArgs,
+      writeSchema: toolSchemaMap.get("write"),
+    },
   );
 
   const normalizedToolCall: OpenAiToolCall = {
@@ -102,10 +107,101 @@ export function applyToolSchemaCompat(
   return {
     toolCall: normalizedToolCall,
     normalizedArgs: sanitization.args,
+    originalArgs: parsedArgs,
     originalArgKeys,
     normalizedArgKeys: Object.keys(sanitization.args),
     collisionKeys,
     validation,
+  };
+}
+
+export function isFullFileShapedEditValidationFailure(
+  toolName: string,
+  args: JsonRecord,
+  validation: ToolSchemaValidationResult,
+  originalArgs: JsonRecord,
+  writeSchema?: unknown,
+): boolean {
+  if (toolName.toLowerCase() !== "edit" || validation.ok) {
+    return false;
+  }
+  return buildEditFullFileHint(args, validation.missing, validation.typeErrors, {
+    originalArgs,
+    writeSchema,
+  }) !== null;
+}
+
+function buildWriteArguments(
+  filePath: string,
+  content: string,
+  writeSchema: unknown,
+): JsonRecord {
+  if (!isRecord(writeSchema)) {
+    return { path: filePath, content };
+  }
+  const required = Array.isArray(writeSchema.required)
+    ? writeSchema.required.filter((value): value is string => typeof value === "string")
+    : [];
+  if (required.includes("filePath")) {
+    return { filePath, content };
+  }
+  return { path: filePath, content };
+}
+
+/** Malformed full-file edit (path + body, no old_string) → write tool call when write is available. */
+export function tryRerouteEditToWrite(
+  toolCall: OpenAiToolCall,
+  compat: ToolSchemaCompatResult,
+  allowedToolNames: Set<string>,
+  toolSchemaMap: Map<string, unknown>,
+): OpenAiToolCall | null {
+  if (toolCall.function.name.toLowerCase() !== "edit") {
+    return null;
+  }
+  if (!allowedToolNames.has("write") || !toolSchemaMap.has("write")) {
+    return null;
+  }
+
+  const writeSchema = toolSchemaMap.get("write");
+  if (
+    !isFullFileShapedEditValidationFailure(
+      toolCall.function.name,
+      compat.normalizedArgs,
+      compat.validation,
+      compat.originalArgs,
+      writeSchema,
+    )
+  ) {
+    return null;
+  }
+
+  const filePath = typeof compat.normalizedArgs.path === "string" && compat.normalizedArgs.path.length > 0
+    ? compat.normalizedArgs.path
+    : typeof compat.normalizedArgs.filePath === "string" && compat.normalizedArgs.filePath.length > 0
+      ? compat.normalizedArgs.filePath
+      : null;
+  if (!filePath) {
+    return null;
+  }
+
+  const content =
+    typeof compat.normalizedArgs.new_string === "string"
+      ? compat.normalizedArgs.new_string
+      : typeof compat.normalizedArgs.newString === "string"
+        ? compat.normalizedArgs.newString
+        : typeof compat.normalizedArgs.content === "string"
+          ? compat.normalizedArgs.content
+          : null;
+  if (content === null) {
+    return null;
+  }
+
+  return {
+    ...toolCall,
+    function: {
+      name: "write",
+      arguments: JSON.stringify(buildWriteArguments(filePath, content, writeSchema)),
+    },
   };
 }
 
@@ -242,8 +338,6 @@ function normalizeToolSpecificArgs(toolName: string, args: JsonRecord): JsonReco
     return args;
   }
 
-  const hadOldStringProperty = hasOwn(args, "old_string");
-
   const repaired: JsonRecord = { ...args };
   const hasStringNew = typeof repaired.new_string === "string";
   const hasStringOld = typeof repaired.old_string === "string";
@@ -265,19 +359,6 @@ function normalizeToolSpecificArgs(toolName: string, args: JsonRecord): JsonReco
   }
   if (hasStringOld && repaired.old_string === "") {
     delete repaired.old_string;
-  }
-
-  // Executor (`resolveEditArguments`) treats missing old_string + new bodies as full-file
-  // replace. Schema requires old_string unless we synthesize empty here. Do not synthesize when
-  // the model explicitly sent old_string (including ""); those are stripped above on purpose.
-  if (
-    !hadOldStringProperty
-    && typeof repaired.path === "string"
-    && repaired.path.trim().length > 0
-    && typeof repaired.new_string === "string"
-    && repaired.old_string === undefined
-  ) {
-    repaired.old_string = "";
   }
 
   return repaired;
@@ -365,11 +446,17 @@ function sanitizeArgumentsForSchema(
   return { args: sanitized, unexpected };
 }
 
+type ValidateToolArgumentsContext = {
+  originalArgs?: JsonRecord;
+  writeSchema?: unknown;
+};
+
 function validateToolArguments(
   toolName: string,
   args: JsonRecord,
   schema: unknown,
   unexpected: string[],
+  context: ValidateToolArgumentsContext = {},
 ): ToolSchemaValidationResult {
   if (!isRecord(schema)) {
     return {
@@ -414,16 +501,90 @@ function validateToolArguments(
     missing,
     unexpected,
     typeErrors,
-    repairHint: ok ? undefined : buildRepairHint(toolName, missing, unexpected, typeErrors),
+    repairHint: ok
+      ? undefined
+      : buildRepairHint(toolName, args, missing, unexpected, typeErrors, context),
   };
+}
+
+function hadOldStringPropertyInPayload(args: JsonRecord): boolean {
+  for (const key of Object.keys(args)) {
+    const token = key.toLowerCase().replace(/[^a-z0-9]/g, "");
+    if (token === "oldstring") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasEditFilePath(args: JsonRecord): boolean {
+  const pathValue = args.path ?? args.filePath;
+  return typeof pathValue === "string" && pathValue.trim().length > 0;
+}
+
+function hasEditBody(args: JsonRecord): boolean {
+  const body = args.new_string ?? args.newString ?? args.content;
+  return typeof body === "string" && body.length > 0;
+}
+
+function writeToolExample(writeSchema: unknown): string {
+  if (!isRecord(writeSchema)) {
+    return "write with path and content";
+  }
+  const required = Array.isArray(writeSchema.required)
+    ? writeSchema.required.filter((value): value is string => typeof value === "string")
+    : [];
+  if (required.includes("filePath")) {
+    return "write with filePath and content";
+  }
+  return "write with path and content";
+}
+
+function buildEditFullFileHint(
+  args: JsonRecord,
+  missing: string[],
+  typeErrors: string[],
+  context: ValidateToolArgumentsContext,
+): string | null {
+  if (typeErrors.length > 0) {
+    return null;
+  }
+
+  const missingOldStringOnly =
+    (missing.includes("old_string") || missing.includes("oldString"))
+    && missing.every((key) => key === "old_string" || key === "oldString");
+  if (!missingOldStringOnly) {
+    return null;
+  }
+
+  const originalArgs = context.originalArgs ?? {};
+  if (hadOldStringPropertyInPayload(originalArgs)) {
+    return null;
+  }
+
+  if (!hasEditFilePath(args) || !hasEditBody(args)) {
+    return null;
+  }
+
+  const example = writeToolExample(context.writeSchema);
+  return `For a full file body, use ${example} instead of edit without old_string`;
 }
 
 function buildRepairHint(
   toolName: string,
+  args: JsonRecord,
   missing: string[],
   unexpected: string[],
   typeErrors: string[],
+  context: ValidateToolArgumentsContext = {},
 ): string {
+  const fullFileHint = toolName.toLowerCase() === "edit"
+    ? buildEditFullFileHint(args, missing, typeErrors, context)
+    : null;
+  if (fullFileHint) {
+    return fullFileHint;
+  }
+
   const hints: string[] = [];
   if (missing.length > 0) {
     hints.push(`missing required: ${missing.join(", ")}`);
@@ -434,12 +595,14 @@ function buildRepairHint(
   if (typeErrors.length > 0) {
     hints.push(`fix type errors: ${typeErrors.join("; ")}`);
   }
+
   if (
     toolName.toLowerCase() === "edit"
-    && (missing.includes("old_string") || missing.includes("new_string"))
+    && (missing.includes("old_string") || missing.includes("oldString") || missing.includes("new_string") || missing.includes("newString"))
   ) {
     hints.push("edit requires path, old_string, and new_string");
   }
+
   return hints.join(" | ");
 }
 

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -163,7 +163,9 @@ export function registerDefaultTools(registry: ToolRegistry): void {
   registry.register({
     id: "edit",
     name: "edit",
-    description: "Edit a file by replacing old text with new text. Use for targeted replacements; use write to overwrite an entire file.",
+    description:
+      "Edit a file by replacing old text with new text. Use for targeted replacements; use write to overwrite an entire file. "
+      + "Some models send `content` instead of `new_string` for a full-file body; that is treated like an empty old_string (overwrite).",
     parameters: {
       type: "object",
       properties: {

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -163,9 +163,7 @@ export function registerDefaultTools(registry: ToolRegistry): void {
   registry.register({
     id: "edit",
     name: "edit",
-    description:
-      "Edit a file by replacing old text with new text. Use for targeted replacements; use write to overwrite an entire file. "
-      + "Some models send `content` instead of `new_string` for a full-file body; that is treated like an empty old_string (overwrite).",
+    description: "Edit a file by replacing old text with new text. Use for targeted replacements; use write to overwrite an entire file.",
     parameters: {
       type: "object",
       properties: {
@@ -533,10 +531,6 @@ function resolveEditArguments(args: Record<string, unknown>): {
     if (fallbackContent !== null) {
       newString = fallbackContent;
     }
-  }
-
-  if (oldString === undefined && newString !== undefined) {
-    oldString = "";
   }
 
   return {

--- a/tests/integration/opencode-loop.integration.test.ts
+++ b/tests/integration/opencode-loop.integration.test.ts
@@ -397,7 +397,7 @@ describe("OpenCode-owned tool loop integration", () => {
     expect(json.choices?.[0]?.finish_reason).toBe("tool_calls");
   });
 
-  it("skips non-streaming edit content payloads without old_string", async () => {
+  it("accepts non-streaming edit with path+content (full rewrite) after schema-compat repair", async () => {
     process.env.MOCK_CURSOR_SCENARIO = "tool-edit-invalid";
     process.env.MOCK_CURSOR_PROMPT_FILE = "";
 
@@ -409,9 +409,12 @@ describe("OpenCode-owned tool loop integration", () => {
     });
 
     const json: any = await response.json();
-    expect(json.choices?.[0]?.message?.tool_calls).toBeUndefined();
-    expect(json.choices?.[0]?.message?.content).toContain("edit fallback text");
-    expect(json.choices?.[0]?.finish_reason).toBe("stop");
+    expect(json.choices?.[0]?.message?.tool_calls?.[0]?.function?.name).toBe("edit");
+    const args = JSON.parse(json.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments ?? "{}");
+    expect(args.path).toBe("TODO.md");
+    expect(args.new_string).toBe("full rewrite");
+    expect(args.old_string).toBe("");
+    expect(json.choices?.[0]?.finish_reason).toBe("tool_calls");
   });
 
   // TODO: Fix test isolation issue - this test passes alone but fails in full suite

--- a/tests/integration/opencode-loop.integration.test.ts
+++ b/tests/integration/opencode-loop.integration.test.ts
@@ -51,6 +51,23 @@ const EDIT_TOOL = {
   },
 };
 
+const WRITE_TOOL = {
+  type: "function",
+  function: {
+    name: "write",
+    description: "Write a file",
+    parameters: {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+      additionalProperties: false,
+    },
+  },
+};
+
 const MOCK_CURSOR_AGENT = `#!/usr/bin/env node
 const fs = require("fs");
 
@@ -397,24 +414,79 @@ describe("OpenCode-owned tool loop integration", () => {
     expect(json.choices?.[0]?.finish_reason).toBe("tool_calls");
   });
 
-  it("accepts non-streaming edit with path+content (full rewrite) after schema-compat repair", async () => {
+  it("reroutes non-streaming edit content payloads to write when write is available", async () => {
     process.env.MOCK_CURSOR_SCENARIO = "tool-edit-invalid";
     process.env.MOCK_CURSOR_PROMPT_FILE = "";
 
     const response = await requestCompletion(baseURL, {
       model: "auto",
       stream: false,
-      tools: [EDIT_TOOL],
+      tools: [EDIT_TOOL, WRITE_TOOL],
       messages: [{ role: "user", content: "Edit TODO.md" }],
     });
 
     const json: any = await response.json();
-    expect(json.choices?.[0]?.message?.tool_calls?.[0]?.function?.name).toBe("edit");
+    expect(json.choices?.[0]?.message?.tool_calls?.[0]?.function?.name).toBe("write");
     const args = JSON.parse(json.choices?.[0]?.message?.tool_calls?.[0]?.function?.arguments ?? "{}");
     expect(args.path).toBe("TODO.md");
-    expect(args.new_string).toBe("full rewrite");
-    expect(args.old_string).toBe("");
+    expect(args.content).toBe("full rewrite");
     expect(json.choices?.[0]?.finish_reason).toBe("tool_calls");
+  });
+
+  it("reroutes streaming edit content payloads to write when write is available", async () => {
+    process.env.MOCK_CURSOR_SCENARIO = "tool-edit-invalid";
+    process.env.MOCK_CURSOR_PROMPT_FILE = "";
+
+    const response = await requestCompletion(baseURL, {
+      model: "auto",
+      stream: true,
+      tools: [EDIT_TOOL, WRITE_TOOL],
+      messages: [{ role: "user", content: "Edit TODO.md" }],
+    });
+
+    const body = await response.text();
+    const dataLines = parseSseData(body);
+    const chunks = parseJsonChunks(dataLines);
+
+    const toolDelta = chunks.find((chunk) => chunk.choices?.[0]?.delta?.tool_calls?.length);
+    expect(toolDelta?.choices?.[0]?.delta?.tool_calls?.[0]?.function?.name).toBe("write");
+    expect(toolDelta?.choices?.[0]?.delta?.tool_calls?.[0]?.function?.arguments).toContain("TODO.md");
+    expect(toolDelta?.choices?.[0]?.delta?.tool_calls?.[0]?.function?.arguments).toContain("full rewrite");
+
+    const finishReasons = chunks.map((chunk) => chunk.choices?.[0]?.finish_reason).filter(Boolean);
+    expect(finishReasons).toContain("tool_calls");
+
+    const allContent = chunks
+      .map((chunk) => chunk.choices?.[0]?.delta?.content)
+      .filter((value): value is string => typeof value === "string")
+      .join("");
+    expect(allContent).not.toContain("Skipped malformed tool call");
+    expect(allContent).not.toContain("edit fallback text");
+  });
+
+  it("skips streaming edit when write tool is not offered", async () => {
+    process.env.MOCK_CURSOR_SCENARIO = "tool-edit-invalid";
+    process.env.MOCK_CURSOR_PROMPT_FILE = "";
+
+    const response = await requestCompletion(baseURL, {
+      model: "auto",
+      stream: true,
+      tools: [EDIT_TOOL],
+      messages: [{ role: "user", content: "Edit TODO.md" }],
+    });
+
+    const body = await response.text();
+    const dataLines = parseSseData(body);
+    const chunks = parseJsonChunks(dataLines);
+
+    const toolDelta = chunks.find((chunk) => chunk.choices?.[0]?.delta?.tool_calls?.length);
+    expect(toolDelta).toBeUndefined();
+
+    const allContent = chunks
+      .map((chunk) => chunk.choices?.[0]?.delta?.content)
+      .filter((value): value is string => typeof value === "string")
+      .join("");
+    expect(allContent).toContain("edit fallback text");
   });
 
   // TODO: Fix test isolation issue - this test passes alone but fails in full suite

--- a/tests/tools/defaults.test.ts
+++ b/tests/tools/defaults.test.ts
@@ -210,26 +210,32 @@ describe("Default Tools", () => {
     expect(result.error).toContain("missing required argument 'old_string'");
   });
 
-  it("should accept edit payloads that only provide content", async () => {
+  it("regression: rejects edit payloads that only provide content without old_string", async () => {
     const registry = new ToolRegistry();
     registerDefaultTools(registry);
     const executor = new LocalExecutor(registry);
-    const fs = await import("fs");
-
-    const tmpFile = `/tmp/test-edit-content-${Date.now()}.txt`;
-    if (fs.existsSync(tmpFile)) {
-      fs.unlinkSync(tmpFile);
-    }
 
     const result = await executeWithChain([executor], "edit", {
-      path: tmpFile,
-      content: "Created from content fallback",
+      path: "/tmp/test-edit-content-only.txt",
+      content: "should not overwrite",
     });
 
-    expect(result.status).toBe("success");
-    expect(fs.readFileSync(tmpFile, "utf-8")).toBe("Created from content fallback");
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("missing required argument 'old_string'");
+  });
 
-    fs.unlinkSync(tmpFile);
+  it("regression: rejects edit payloads that only provide new_string without old_string", async () => {
+    const registry = new ToolRegistry();
+    registerDefaultTools(registry);
+    const executor = new LocalExecutor(registry);
+
+    const result = await executeWithChain([executor], "edit", {
+      path: "/tmp/test-edit-new-only.txt",
+      new_string: "should not overwrite",
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toContain("missing required argument 'old_string'");
   });
 
   it("should get all tool definitions", () => {

--- a/tests/unit/provider-runtime-interception.test.ts
+++ b/tests/unit/provider-runtime-interception.test.ts
@@ -278,8 +278,8 @@ describe("provider runtime interception fallback", () => {
     expect(interceptedArgs).toContain("\"content\":\"hello\"");
   });
 
-  it("emits a non-fatal hint for edit content payloads without old_string in v1", async () => {
-    let interceptedCount = 0;
+  it("intercepts edit content payloads without old_string in v1 after schema-compat repair", async () => {
+    const interceptedArgs: string[] = [];
     const toolResults: any[] = [];
     const result = await handleToolLoopEventV1({
       ...createBaseOptions({
@@ -311,18 +311,20 @@ describe("provider runtime interception fallback", () => {
         onToolResult: async (toolResult) => {
           toolResults.push(toolResult);
         },
-        onInterceptedToolCall: async () => {
-          interceptedCount += 1;
+        onInterceptedToolCall: async (toolCall) => {
+          interceptedArgs.push(toolCall.function.arguments);
         },
       }),
       boundary: createProviderBoundary("v1", "cursor-acp"),
     });
 
-    expect(result).toEqual({ intercepted: false, skipConverter: true });
-    expect(interceptedCount).toBe(0);
-    expect(toolResults).toHaveLength(1);
-    expect(toolResults[0]?.choices?.[0]?.delta?.content).toContain("Skipped malformed tool call");
-    expect(toolResults[0]?.choices?.[0]?.delta?.content).toContain("old_string");
+    expect(result).toEqual({ intercepted: true, skipConverter: true });
+    expect(toolResults).toHaveLength(0);
+    expect(interceptedArgs).toHaveLength(1);
+    const parsed = JSON.parse(interceptedArgs[0] ?? "{}");
+    expect(parsed.path).toBe("TODO.md");
+    expect(parsed.new_string).toBe("full rewrite");
+    expect(parsed.old_string).toBe("");
   });
 
   it("emits a non-fatal hint for explicit empty edit old_string in v1", async () => {

--- a/tests/unit/provider-runtime-interception.test.ts
+++ b/tests/unit/provider-runtime-interception.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { OpenAiToolCall } from "../../src/proxy/tool-loop";
 import { createProviderBoundary } from "../../src/provider/boundary";
 import { createToolLoopGuard } from "../../src/provider/tool-loop-guard";
 import {
@@ -52,6 +53,52 @@ function createBaseOptions(overrides: Partial<EventOptions> = {}): EventOptions 
   return { ...base, ...overrides };
 }
 
+const EDIT_WRITE_SCHEMA_MAP = new Map([
+  [
+    "edit",
+    {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        old_string: { type: "string" },
+        new_string: { type: "string" },
+      },
+      required: ["path", "old_string", "new_string"],
+      additionalProperties: false,
+    },
+  ],
+  [
+    "write",
+    {
+      type: "object",
+      properties: {
+        path: { type: "string" },
+        content: { type: "string" },
+      },
+      required: ["path", "content"],
+    },
+  ],
+]);
+
+function createEditPathContentRerouteOverrides(
+  overrides: Partial<EventOptions> = {},
+): Partial<EventOptions> {
+  return {
+    event: {
+      type: "tool_call",
+      call_id: "c_edit_reroute",
+      tool_call: {
+        editToolCall: {
+          args: { path: "TODO.md", content: "full rewrite" },
+        },
+      },
+    } as any,
+    allowedToolNames: new Set(["edit", "write"]),
+    toolSchemaMap: EDIT_WRITE_SCHEMA_MAP,
+    ...overrides,
+  };
+}
+
 describe("provider runtime interception parity", () => {
   it("produces equivalent interception results for legacy and v1 in opencode mode", async () => {
     const legacyOptions = createBaseOptions();
@@ -65,6 +112,42 @@ describe("provider runtime interception parity", () => {
 
     expect(legacyResult).toEqual({ intercepted: true, skipConverter: true });
     expect(v1Result).toEqual(legacyResult);
+  });
+
+  it("legacy and v1 agree on edit path+content reroute to write", async () => {
+    const interceptedLegacy: OpenAiToolCall[] = [];
+    const interceptedV1: OpenAiToolCall[] = [];
+    const rerouteOverrides = createEditPathContentRerouteOverrides();
+
+    const legacyResult = await handleToolLoopEventLegacy(
+      createBaseOptions({
+        ...rerouteOverrides,
+        onInterceptedToolCall: async (toolCall) => {
+          interceptedLegacy.push(toolCall);
+        },
+      }),
+    );
+    const v1Result = await handleToolLoopEventV1({
+      ...createBaseOptions({
+        ...rerouteOverrides,
+        onInterceptedToolCall: async (toolCall) => {
+          interceptedV1.push(toolCall);
+        },
+      }),
+      boundary: createProviderBoundary("v1", "cursor-acp"),
+    });
+
+    expect(legacyResult).toEqual({ intercepted: true, skipConverter: true });
+    expect(v1Result).toEqual(legacyResult);
+    expect(interceptedLegacy).toHaveLength(1);
+    expect(interceptedV1).toHaveLength(1);
+    expect(interceptedLegacy[0]?.function.name).toBe("write");
+    expect(interceptedV1[0]?.function.name).toBe("write");
+    const legacyArgs = JSON.parse(interceptedLegacy[0]?.function.arguments ?? "{}");
+    const v1Args = JSON.parse(interceptedV1[0]?.function.arguments ?? "{}");
+    expect(legacyArgs).toEqual(v1Args);
+    expect(legacyArgs.path).toBe("TODO.md");
+    expect(legacyArgs.content).toBe("full rewrite");
   });
 
   it("produces equivalent proxy-exec passthrough behavior in legacy and v1", async () => {
@@ -278,41 +361,17 @@ describe("provider runtime interception fallback", () => {
     expect(interceptedArgs).toContain("\"content\":\"hello\"");
   });
 
-  it("intercepts edit content payloads without old_string in v1 after schema-compat repair", async () => {
-    const interceptedArgs: string[] = [];
+  it("reroutes path+content edit missing old_string to write in v1", async () => {
+    const intercepted: OpenAiToolCall[] = [];
     const toolResults: any[] = [];
     const result = await handleToolLoopEventV1({
       ...createBaseOptions({
-        event: {
-          type: "tool_call",
-          call_id: "c4",
-          tool_call: {
-            editToolCall: {
-              args: { path: "TODO.md", content: "full rewrite" },
-            },
-          },
-        } as any,
-        allowedToolNames: new Set(["edit"]),
-        toolSchemaMap: new Map([
-          [
-            "edit",
-            {
-              type: "object",
-              properties: {
-                path: { type: "string" },
-                old_string: { type: "string" },
-                new_string: { type: "string" },
-              },
-              required: ["path", "old_string", "new_string"],
-              additionalProperties: false,
-            },
-          ],
-        ]),
+        ...createEditPathContentRerouteOverrides(),
         onToolResult: async (toolResult) => {
           toolResults.push(toolResult);
         },
         onInterceptedToolCall: async (toolCall) => {
-          interceptedArgs.push(toolCall.function.arguments);
+          intercepted.push(toolCall);
         },
       }),
       boundary: createProviderBoundary("v1", "cursor-acp"),
@@ -320,11 +379,61 @@ describe("provider runtime interception fallback", () => {
 
     expect(result).toEqual({ intercepted: true, skipConverter: true });
     expect(toolResults).toHaveLength(0);
-    expect(interceptedArgs).toHaveLength(1);
-    const parsed = JSON.parse(interceptedArgs[0] ?? "{}");
-    expect(parsed.path).toBe("TODO.md");
-    expect(parsed.new_string).toBe("full rewrite");
-    expect(parsed.old_string).toBe("");
+    expect(intercepted).toHaveLength(1);
+    expect(intercepted[0]?.function.name).toBe("write");
+    const args = JSON.parse(intercepted[0]?.function.arguments ?? "{}");
+    expect(args.path).toBe("TODO.md");
+    expect(args.content).toBe("full rewrite");
+  });
+
+  it("reroutes path+content edit missing old_string to write in legacy", async () => {
+    const intercepted: OpenAiToolCall[] = [];
+    const toolResults: any[] = [];
+    const result = await handleToolLoopEventLegacy(
+      createBaseOptions({
+        ...createEditPathContentRerouteOverrides(),
+        onToolResult: async (toolResult) => {
+          toolResults.push(toolResult);
+        },
+        onInterceptedToolCall: async (toolCall) => {
+          intercepted.push(toolCall);
+        },
+      }),
+    );
+
+    expect(result).toEqual({ intercepted: true, skipConverter: true });
+    expect(toolResults).toHaveLength(0);
+    expect(intercepted).toHaveLength(1);
+    expect(intercepted[0]?.function.name).toBe("write");
+  });
+
+  it("falls back to hint when write unavailable for path+content edit", async () => {
+    const toolResults: any[] = [];
+    let interceptedCount = 0;
+    const result = await handleToolLoopEventV1({
+      ...createBaseOptions({
+        ...createEditPathContentRerouteOverrides({
+          allowedToolNames: new Set(["edit"]),
+        }),
+        onToolResult: async (toolResult) => {
+          toolResults.push(toolResult);
+        },
+        onInterceptedToolCall: async () => {
+          interceptedCount += 1;
+        },
+      }),
+      boundary: createProviderBoundary("v1", "cursor-acp"),
+      schemaValidationFailureMode: "pass_through",
+    });
+
+    expect(result).toEqual({ intercepted: false, skipConverter: true });
+    expect(interceptedCount).toBe(0);
+    expect(toolResults).toHaveLength(1);
+    const hint = toolResults[0]?.choices?.[0]?.delta?.content ?? "";
+    expect(hint).toContain("Skipped malformed tool call");
+    expect(hint).toContain("write");
+    expect(hint.match(/missing required: old_string/g)?.length).toBe(1);
+    expect(hint).not.toContain("missing required: old_string. missing required: old_string");
   });
 
   it("emits a non-fatal hint for explicit empty edit old_string in v1", async () => {

--- a/tests/unit/provider-tool-schema-compat.test.ts
+++ b/tests/unit/provider-tool-schema-compat.test.ts
@@ -272,7 +272,7 @@ describe("tool schema compatibility", () => {
     expect(todos[4].priority).toBe("medium");
   });
 
-  it("repairs edit content payloads into new_string without synthesizing empty old_string", () => {
+  it("repairs edit content payloads into new_string and synthesizes empty old_string for validation", () => {
     const result = applyToolSchemaCompat(
       {
         id: "c1",
@@ -304,11 +304,11 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("/tmp/todo.md");
-    expect(args.old_string).toBeUndefined();
+    expect(args.old_string).toBe("");
     expect(args.new_string).toBe("new full content");
     expect(args.content).toBeUndefined();
-    expect(result.validation.ok).toBe(false);
-    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.ok).toBe(true);
+    expect(result.validation.missing).toEqual([]);
     expect(result.validation.typeErrors).toEqual([]);
   });
 
@@ -415,10 +415,10 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("TODO.md");
-    expect(args.old_string).toBeUndefined();
+    expect(args.old_string).toBe("");
     expect(args.new_string).toBe("updated body");
-    expect(result.validation.ok).toBe(false);
-    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.ok).toBe(true);
+    expect(result.validation.missing).toEqual([]);
   });
 
   it("coerces array streamContent chunks into edit new_string", () => {
@@ -453,12 +453,12 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("TODO.md");
-    expect(args.old_string).toBeUndefined();
+    expect(args.old_string).toBe("");
     expect(args.new_string).toBe("# Travel Plan\n- Flight\n- Hotel\n");
     expect(args.streamContent).toBeUndefined();
     expect(args.content).toBeUndefined();
-    expect(result.validation.ok).toBe(false);
-    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.ok).toBe(true);
+    expect(result.validation.missing).toEqual([]);
   });
 
   it("coerces object-wrapped content into edit new_string", () => {
@@ -493,11 +493,11 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("SIMPLE_TEST.md");
-    expect(args.old_string).toBeUndefined();
+    expect(args.old_string).toBe("");
     expect(typeof args.new_string).toBe("string");
     expect(args.new_string.length).toBeGreaterThan(0);
-    expect(result.validation.ok).toBe(false);
-    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.ok).toBe(true);
+    expect(result.validation.missing).toEqual([]);
   });
 
   it("coerces nested array of {text} chunk objects into edit new_string", () => {
@@ -536,10 +536,10 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("TODO.md");
-    expect(args.old_string).toBeUndefined();
+    expect(args.old_string).toBe("");
     expect(args.new_string).toBe("# Plan\n- Step 1\n- Step 2\n");
-    expect(result.validation.ok).toBe(false);
-    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.ok).toBe(true);
+    expect(result.validation.missing).toEqual([]);
   });
 
   it("rejects explicit empty edit old_string instead of preserving a full-file replacement", () => {
@@ -579,6 +579,43 @@ describe("tool schema compatibility", () => {
     expect(args.new_string).toBe("-- test\nreturn {");
     expect(result.validation.ok).toBe(false);
     expect(result.validation.missing).toEqual(["old_string"]);
+  });
+
+  it("synthesizes empty old_string for edit with path and new_string only (no content key)", () => {
+    const result = applyToolSchemaCompat(
+      {
+        id: "c_path_new_only",
+        type: "function",
+        function: {
+          name: "edit",
+          arguments: JSON.stringify({
+            path: "/tmp/out.txt",
+            new_string: "entire body",
+          }),
+        },
+      },
+      new Map([
+        [
+          "edit",
+          {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              old_string: { type: "string" },
+              new_string: { type: "string" },
+            },
+            required: ["path", "old_string", "new_string"],
+            additionalProperties: false,
+          },
+        ],
+      ]),
+    );
+
+    const args = JSON.parse(result.toolCall.function.arguments);
+    expect(args.path).toBe("/tmp/out.txt");
+    expect(args.old_string).toBe("");
+    expect(args.new_string).toBe("entire body");
+    expect(result.validation.ok).toBe(true);
   });
 
   it("preserves valid edit calls with explicit old/new strings", () => {

--- a/tests/unit/provider-tool-schema-compat.test.ts
+++ b/tests/unit/provider-tool-schema-compat.test.ts
@@ -1,8 +1,60 @@
 import { describe, expect, it } from "bun:test";
+import type { OpenAiToolCall } from "../../src/proxy/tool-loop";
 import {
   applyToolSchemaCompat,
   buildToolSchemaMap,
+  isFullFileShapedEditValidationFailure,
+  tryRerouteEditToWrite,
 } from "../../src/provider/tool-schema-compat";
+
+function buildEditWriteSchemaMap(writeUsesFilePath = false): Map<string, unknown> {
+  return new Map([
+    [
+      "edit",
+      {
+        type: "object",
+        properties: {
+          path: { type: "string" },
+          old_string: { type: "string" },
+          new_string: { type: "string" },
+        },
+        required: ["path", "old_string", "new_string"],
+        additionalProperties: false,
+      },
+    ],
+    [
+      "write",
+      writeUsesFilePath
+        ? {
+            type: "object",
+            properties: {
+              filePath: { type: "string" },
+              content: { type: "string" },
+            },
+            required: ["filePath", "content"],
+          }
+        : {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              content: { type: "string" },
+            },
+            required: ["path", "content"],
+          },
+    ],
+  ]);
+}
+
+function editToolCall(args: Record<string, unknown>, id = "c_edit"): OpenAiToolCall {
+  return {
+    id,
+    type: "function",
+    function: {
+      name: "edit",
+      arguments: JSON.stringify(args),
+    },
+  };
+}
 
 describe("tool schema compatibility", () => {
   it("normalizes common argument aliases to canonical keys", () => {
@@ -272,7 +324,7 @@ describe("tool schema compatibility", () => {
     expect(todos[4].priority).toBe("medium");
   });
 
-  it("repairs edit content payloads into new_string and synthesizes empty old_string for validation", () => {
+  it("regression: does not synthesize old_string for path+content edit", () => {
     const result = applyToolSchemaCompat(
       {
         id: "c1",
@@ -304,12 +356,12 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("/tmp/todo.md");
-    expect(args.old_string).toBe("");
+    expect(args.old_string).toBeUndefined();
     expect(args.new_string).toBe("new full content");
     expect(args.content).toBeUndefined();
-    expect(result.validation.ok).toBe(true);
-    expect(result.validation.missing).toEqual([]);
-    expect(result.validation.typeErrors).toEqual([]);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.repairHint).toContain("write");
   });
 
   it("repairs edit content into new_string even when path is missing", () => {
@@ -415,10 +467,11 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("TODO.md");
-    expect(args.old_string).toBe("");
+    expect(args.old_string).toBeUndefined();
     expect(args.new_string).toBe("updated body");
-    expect(result.validation.ok).toBe(true);
-    expect(result.validation.missing).toEqual([]);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.repairHint).toContain("write");
   });
 
   it("coerces array streamContent chunks into edit new_string", () => {
@@ -453,12 +506,12 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("TODO.md");
-    expect(args.old_string).toBe("");
+    expect(args.old_string).toBeUndefined();
     expect(args.new_string).toBe("# Travel Plan\n- Flight\n- Hotel\n");
     expect(args.streamContent).toBeUndefined();
     expect(args.content).toBeUndefined();
-    expect(result.validation.ok).toBe(true);
-    expect(result.validation.missing).toEqual([]);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.missing).toEqual(["old_string"]);
   });
 
   it("coerces object-wrapped content into edit new_string", () => {
@@ -493,11 +546,11 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("SIMPLE_TEST.md");
-    expect(args.old_string).toBe("");
+    expect(args.old_string).toBeUndefined();
     expect(typeof args.new_string).toBe("string");
     expect(args.new_string.length).toBeGreaterThan(0);
-    expect(result.validation.ok).toBe(true);
-    expect(result.validation.missing).toEqual([]);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.missing).toEqual(["old_string"]);
   });
 
   it("coerces nested array of {text} chunk objects into edit new_string", () => {
@@ -536,10 +589,10 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("TODO.md");
-    expect(args.old_string).toBe("");
+    expect(args.old_string).toBeUndefined();
     expect(args.new_string).toBe("# Plan\n- Step 1\n- Step 2\n");
-    expect(result.validation.ok).toBe(true);
-    expect(result.validation.missing).toEqual([]);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.missing).toEqual(["old_string"]);
   });
 
   it("rejects explicit empty edit old_string instead of preserving a full-file replacement", () => {
@@ -581,7 +634,7 @@ describe("tool schema compatibility", () => {
     expect(result.validation.missing).toEqual(["old_string"]);
   });
 
-  it("synthesizes empty old_string for edit with path and new_string only (no content key)", () => {
+  it("regression: does not synthesize old_string for path+new_string only", () => {
     const result = applyToolSchemaCompat(
       {
         id: "c_path_new_only",
@@ -613,9 +666,167 @@ describe("tool schema compatibility", () => {
 
     const args = JSON.parse(result.toolCall.function.arguments);
     expect(args.path).toBe("/tmp/out.txt");
-    expect(args.old_string).toBe("");
+    expect(args.old_string).toBeUndefined();
     expect(args.new_string).toBe("entire body");
-    expect(result.validation.ok).toBe(true);
+    expect(result.validation.ok).toBe(false);
+    expect(result.validation.missing).toEqual(["old_string"]);
+    expect(result.validation.repairHint).toContain("write");
+  });
+
+  describe("edit to write reroute", () => {
+    it("full-file hint uses filePath when write schema requires filePath", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(true);
+      const result = applyToolSchemaCompat(
+        editToolCall({ path: "/tmp/out.txt", content: "entire body" }, "c_file_path_write_hint"),
+        toolSchemaMap,
+      );
+
+      expect(result.validation.ok).toBe(false);
+      expect(result.validation.repairHint).toContain("filePath");
+      expect(result.validation.repairHint).toContain("write");
+    });
+
+    it("tryRerouteEditToWrite converts path+content edit to write", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(false);
+      const call = editToolCall({ path: "/tmp/x", content: "body" }, "c_reroute");
+      const compat = applyToolSchemaCompat(call, toolSchemaMap);
+      const rerouted = tryRerouteEditToWrite(
+        call,
+        compat,
+        new Set(["edit", "write"]),
+        toolSchemaMap,
+      );
+      expect(rerouted?.function.name).toBe("write");
+      const args = JSON.parse(rerouted?.function.arguments ?? "{}");
+      expect(args.path).toBe("/tmp/x");
+      expect(args.content).toBe("body");
+    });
+
+    it("tryRerouteEditToWrite uses filePath when write schema requires filePath", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(true);
+      const call = editToolCall({ path: "/tmp/x", content: "body" });
+      const compat = applyToolSchemaCompat(call, toolSchemaMap);
+      const rerouted = tryRerouteEditToWrite(
+        call,
+        compat,
+        new Set(["edit", "write"]),
+        toolSchemaMap,
+      );
+      expect(rerouted?.function.name).toBe("write");
+      const args = JSON.parse(rerouted?.function.arguments ?? "{}");
+      expect(args.filePath).toBe("/tmp/x");
+      expect(args.content).toBe("body");
+      expect(args.path).toBeUndefined();
+    });
+
+    it("tryRerouteEditToWrite returns null when write not in allowedToolNames", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(false);
+      const call = editToolCall({ path: "/tmp/x", content: "body" });
+      const compat = applyToolSchemaCompat(call, toolSchemaMap);
+      const rerouted = tryRerouteEditToWrite(call, compat, new Set(["edit"]), toolSchemaMap);
+      expect(rerouted).toBeNull();
+      expect(compat.validation.ok).toBe(false);
+    });
+
+    it("tryRerouteEditToWrite returns null when write missing from schema map", () => {
+      const editOnlyMap = new Map([
+        [
+          "edit",
+          {
+            type: "object",
+            properties: {
+              path: { type: "string" },
+              old_string: { type: "string" },
+              new_string: { type: "string" },
+            },
+            required: ["path", "old_string", "new_string"],
+          },
+        ],
+      ]);
+      const call = editToolCall({ path: "/tmp/x", content: "body" });
+      const compat = applyToolSchemaCompat(call, editOnlyMap);
+      const rerouted = tryRerouteEditToWrite(
+        call,
+        compat,
+        new Set(["edit", "write"]),
+        editOnlyMap,
+      );
+      expect(rerouted).toBeNull();
+    });
+
+    it("tryRerouteEditToWrite returns null for explicit old_string empty", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(false);
+      const call = editToolCall({
+        path: "TODO.md",
+        old_string: "",
+        new_string: "replacement",
+      });
+      const compat = applyToolSchemaCompat(call, toolSchemaMap);
+      const rerouted = tryRerouteEditToWrite(
+        call,
+        compat,
+        new Set(["edit", "write"]),
+        toolSchemaMap,
+      );
+      expect(rerouted).toBeNull();
+      expect(compat.validation.missing).toEqual(["old_string"]);
+    });
+
+    it("tryRerouteEditToWrite returns null when path missing", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(false);
+      const call = editToolCall({ content: "body only" });
+      const compat = applyToolSchemaCompat(call, toolSchemaMap);
+      const rerouted = tryRerouteEditToWrite(
+        call,
+        compat,
+        new Set(["edit", "write"]),
+        toolSchemaMap,
+      );
+      expect(rerouted).toBeNull();
+    });
+
+    it("tryRerouteEditToWrite reroutes after streamContent repair", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(false);
+      const call = editToolCall({ path: "TODO.md", streamContent: "updated body" });
+      const compat = applyToolSchemaCompat(call, toolSchemaMap);
+      const rerouted = tryRerouteEditToWrite(
+        call,
+        compat,
+        new Set(["edit", "write"]),
+        toolSchemaMap,
+      );
+      expect(rerouted?.function.name).toBe("write");
+      const args = JSON.parse(rerouted?.function.arguments ?? "{}");
+      expect(args.path).toBe("TODO.md");
+      expect(args.content).toBe("updated body");
+    });
+
+    it("isFullFileShapedEditValidationFailure true only for full-file shape", () => {
+      const toolSchemaMap = buildEditWriteSchemaMap(false);
+      const fullFileCall = editToolCall({ path: "/tmp/x", content: "body" });
+      const fullFileCompat = applyToolSchemaCompat(fullFileCall, toolSchemaMap);
+      expect(
+        isFullFileShapedEditValidationFailure(
+          "edit",
+          fullFileCompat.normalizedArgs,
+          fullFileCompat.validation,
+          fullFileCompat.originalArgs,
+          toolSchemaMap.get("write"),
+        ),
+      ).toBe(true);
+
+      const missingPathCall = editToolCall({ content: "body only" });
+      const missingPathCompat = applyToolSchemaCompat(missingPathCall, toolSchemaMap);
+      expect(
+        isFullFileShapedEditValidationFailure(
+          "edit",
+          missingPathCompat.normalizedArgs,
+          missingPathCompat.validation,
+          missingPathCompat.originalArgs,
+          toolSchemaMap.get("write"),
+        ),
+      ).toBe(false);
+    });
   });
 
   it("preserves valid edit calls with explicit old/new strings", () => {


### PR DESCRIPTION
## Summary

Fixes flaky read/write/edit in **OpenCode-owned tool loop** mode when the agent sends `edit` with a file path and full body but no `old_string`.

### Problem

The agent often calls `edit` with `path` + `content` (or `new_string` only), not the strict `path` + `old_string` + `new_string` shape. Schema validation failed, so the proxy skipped execution and streamed:

```
Skipped malformed tool call "edit": Invalid arguments for tool "edit": missing required: old_string.
```

The task might still finish via `bash` or a later retry, but the session looked broken.

An earlier approach on this branch synthesized `old_string: ""` to pass validation. That matches fab1475’s concern: it makes **edit** silently mean “replace the whole file.”

### Fix

- **Do not** auto-fill `old_string` with `""` for schema validation.
- When the payload is clearly a full-file-style `edit` (path + body, no `old_string`) and **write** is available, **reroute to `write`** at the provider boundary (restores the pre-fab1475 `tryRerouteEditToWrite` idea for that case only).
- When `write` is not in the tool list, skip and emit a short hint to use `write`.
- Explicit `old_string: ""` from the agent is still stripped and rejected (fab1475 unchanged).
- Other malformed shapes (e.g. `edit` with body but no path) are not rerouted — hint or skip only.
- Executor (`resolveEditArguments`) no longer defaults missing `old_string` to empty.

### Tests

- Unit: `tryRerouteEditToWrite` matrix (path/content, filePath write schema, streamContent, null cases)
- Unit: regression — no `old_string: ""` synthesis
- Unit: runtime interception — legacy + v1 reroute parity, hint fallback when write unavailable
- Integration: non-streaming and streaming reroute when `edit` + `write` tools offered
- Integration: hint path when only `edit` is offered
- Tools: executor rejects content-only / new_string-only edit

## Test plan

- [x] `bun test tests/unit/provider-tool-schema-compat.test.ts`
- [x] `bun test tests/unit/provider-runtime-interception.test.ts`
- [x] `bun test tests/tools/defaults.test.ts`
- [x] `bun test tests/integration/opencode-loop.integration.test.ts`

**Manual:** OpenCode + `cursor-acp` — ask to write a file under `/tmp/`; expect `write` (or reroute), not repeated skip spam.