### PR TITLE
fix(mcp): recommend direct mcp__* tool calls instead of mcptool CLI

### DIFF
--- a/src/mcp/tool-bridge.ts
+++ b/src/mcp/tool-bridge.ts
@@ -4,6 +4,8 @@ import type { McpClientManager } from "./client-manager.js";
 
 const log = createLogger("mcp:tool-bridge");
 
+export const MCP_TOOL_PREFIX = "mcp__";
+
 interface DiscoveredMcpTool {
   name: string;
   serverName: string;
@@ -79,7 +81,7 @@ export function buildMcpToolDefinitions(tools: DiscoveredMcpTool[]): any[] {
 function namespaceMcpTool(serverName: string, toolName: string): string {
   const sanitizedServer = serverName.replace(/[^a-zA-Z0-9]/g, "_");
   const sanitizedTool = toolName.replace(/[^a-zA-Z0-9]/g, "_");
-  return `mcp__${sanitizedServer}__${sanitizedTool}`;
+  return `${MCP_TOOL_PREFIX}${sanitizedServer}__${sanitizedTool}`;
 }
 
 function mcpSchemaToZod(inputSchema: Record<string, unknown> | undefined, z: any): any {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -33,6 +33,7 @@ import { SkillResolver } from "./tools/skills/resolver.js";
 import { autoRefreshModels } from "./models/sync.js";
 import { readMcpConfigs, readSubagentNames } from "./mcp/config.js";
 import { McpClientManager } from "./mcp/client-manager.js";
+import { MCP_TOOL_PREFIX } from "./mcp/tool-bridge.js";
 import { buildMcpToolHookEntries, buildMcpToolDefinitions } from "./mcp/tool-bridge.js";
 import { createOpencodeClient } from "@opencode-ai/sdk";
 import { ToolRegistry as CoreRegistry } from "./tools/core/registry.js";
@@ -93,8 +94,8 @@ export function buildAvailableToolsSystemMessage(
     }
 
     const lines: string[] = [
-      "MCP TOOLS — Use via Shell with the `mcptool` CLI.",
-      "Syntax: mcptool call <server> <tool> [json-args]",
+      `MCP TOOLS — Use via direct tool calls (\`${MCP_TOOL_PREFIX}<server>__<tool>\`).`,
+      "These tools are exposed as first-class tool calls (e.g. mcp__filesystem__read_file).",
       "",
     ];
 
@@ -103,11 +104,6 @@ export function buildAvailableToolsSystemMessage(
       for (const t of tools) {
         const paramHint = t.params?.length ? ` (params: ${t.params.join(", ")})` : "";
         lines.push(`  - ${t.toolName}${paramHint}${t.description ? " — " + t.description : ""}`);
-      }
-      if (tools.length > 0) {
-        const ex = tools[0];
-        const exArgs = ex.params?.length ? ` '{"${ex.params[0]}":"..."}'` : "";
-        lines.push(`  Example: mcptool call ${server} ${ex.toolName}${exArgs}`);
       }
       lines.push("");
     }

--- a/tests/unit/plugin-mcp-system-transform.test.ts
+++ b/tests/unit/plugin-mcp-system-transform.test.ts
@@ -12,7 +12,7 @@ describe("Plugin MCP system transform", () => {
     expect(systemMessage).toContain("skill_search -> search");
   });
 
-  it("includes mcptool Shell instructions when summaries provided", () => {
+  it("includes direct MCP tool call instructions when summaries provided", () => {
     const systemMessage = buildAvailableToolsSystemMessage(
       ["read", "write"],
       [],
@@ -37,15 +37,15 @@ describe("Plugin MCP system transform", () => {
       ],
     );
 
-    expect(systemMessage).toContain("mcptool call");
+    expect(systemMessage).toContain("direct tool calls");
+    expect(systemMessage).toContain("mcp__");
     expect(systemMessage).toContain("hybrid-memory");
     expect(systemMessage).toContain("memory_search");
     expect(systemMessage).toContain("memory_stats");
     expect(systemMessage).toContain("query, limit");
-    expect(systemMessage).toContain("Shell");
   });
 
-  it("includes multiple servers in Shell instructions", () => {
+  it("includes multiple servers in MCP tool instructions", () => {
     const systemMessage = buildAvailableToolsSystemMessage(
       [],
       [],


### PR DESCRIPTION
## Summary

Minimal change to address the MCP permission bypass vulnerability (#74) by updating the system message to instruct the model to use direct tool calls (`mcp__<server>__<tool>`) instead of the `mcptool` CLI via shell.

## Why this scope?

After review feedback, this PR was reduced to the smallest possible change that moves in the right direction. The original broader PR included schema fallback, tool hook changes, and edit→write rerouting — all deferred to follow-up PRs per maintainer request.

## Changes

- Export `MCP_TOOL_PREFIX` constant from `src/mcp/tool-bridge.ts`
- Update system message in `src/plugin.ts` to recommend direct `mcp__*` calls instead of `mcptool` via shell
- Update corresponding test expectations

## Test Results

Local testing confirmed:

- `ls` and `grep` (MCP tools) work reliably via direct `mcp__*` calls
- File read/write operations still bypass permissions in some cases (the model appears to fall back to shell-based access)

This validates that first-class MCP tool calls are viable for several tools, but a follow-up PR with a hybrid approach (prompt + backend interception layer) is needed to fully close the permission bypass for file operations.

## Related

Addresses #74