### PR TITLE
fix(mcp): show exact callable tool names in prompt

### DIFF
--- a/src/mcp/tool-bridge.ts
+++ b/src/mcp/tool-bridge.ts
@@ -78,7 +78,7 @@ export function buildMcpToolDefinitions(tools: DiscoveredMcpTool[]): any[] {
   return defs;
 }
 
-function namespaceMcpTool(serverName: string, toolName: string): string {
+export function namespaceMcpTool(serverName: string, toolName: string): string {
   const sanitizedServer = serverName.replace(/[^a-zA-Z0-9]/g, "_");
   const sanitizedTool = toolName.replace(/[^a-zA-Z0-9]/g, "_");
   return `${MCP_TOOL_PREFIX}${sanitizedServer}__${sanitizedTool}`;

--- a/src/mcp/tool-bridge.ts
+++ b/src/mcp/tool-bridge.ts
@@ -4,6 +4,8 @@ import type { McpClientManager } from "./client-manager.js";
 
 const log = createLogger("mcp:tool-bridge");
 
+export const MCP_TOOL_PREFIX = "mcp__";
+
 interface DiscoveredMcpTool {
   name: string;
   serverName: string;
@@ -79,7 +81,7 @@ export function buildMcpToolDefinitions(tools: DiscoveredMcpTool[]): any[] {
 function namespaceMcpTool(serverName: string, toolName: string): string {
   const sanitizedServer = serverName.replace(/[^a-zA-Z0-9]/g, "_");
   const sanitizedTool = toolName.replace(/[^a-zA-Z0-9]/g, "_");
-  return `mcp__${sanitizedServer}__${sanitizedTool}`;
+  return `${MCP_TOOL_PREFIX}${sanitizedServer}__${sanitizedTool}`;
 }
 
 function mcpSchemaToZod(inputSchema: Record<string, unknown> | undefined, z: any): any {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -33,6 +33,7 @@ import { SkillResolver } from "./tools/skills/resolver.js";
 import { autoRefreshModels } from "./models/sync.js";
 import { readMcpConfigs, readSubagentNames } from "./mcp/config.js";
 import { McpClientManager } from "./mcp/client-manager.js";
+import { MCP_TOOL_PREFIX } from "./mcp/tool-bridge.js";
 import { buildMcpToolHookEntries, buildMcpToolDefinitions } from "./mcp/tool-bridge.js";
 import { createOpencodeClient } from "@opencode-ai/sdk";
 import { ToolRegistry as CoreRegistry } from "./tools/core/registry.js";
@@ -93,8 +94,8 @@ export function buildAvailableToolsSystemMessage(
     }
 
     const lines: string[] = [
-      "MCP TOOLS — Use via Shell with the `mcptool` CLI.",
-      "Syntax: mcptool call <server> <tool> [json-args]",
+      `MCP TOOLS — Use via direct tool calls (\`${MCP_TOOL_PREFIX}<server>__<tool>\`).`,
+      "These tools are exposed as first-class tool calls (e.g. mcp__filesystem__read_file).",
       "",
     ];
 
@@ -103,11 +104,6 @@ export function buildAvailableToolsSystemMessage(
       for (const t of tools) {
         const paramHint = t.params?.length ? ` (params: ${t.params.join(", ")})` : "";
         lines.push(`  - ${t.toolName}${paramHint}${t.description ? " — " + t.description : ""}`);
-      }
-      if (tools.length > 0) {
-        const ex = tools[0];
-        const exArgs = ex.params?.length ? ` '{"${ex.params[0]}":"..."}'` : "";
-        lines.push(`  Example: mcptool call ${server} ${ex.toolName}${exArgs}`);
       }
       lines.push("");
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -33,8 +33,12 @@ import { SkillResolver } from "./tools/skills/resolver.js";
 import { autoRefreshModels } from "./models/sync.js";
 import { readMcpConfigs, readSubagentNames } from "./mcp/config.js";
 import { McpClientManager } from "./mcp/client-manager.js";
-import { MCP_TOOL_PREFIX } from "./mcp/tool-bridge.js";
-import { buildMcpToolHookEntries, buildMcpToolDefinitions } from "./mcp/tool-bridge.js";
+import {
+  MCP_TOOL_PREFIX,
+  buildMcpToolHookEntries,
+  buildMcpToolDefinitions,
+  namespaceMcpTool,
+} from "./mcp/tool-bridge.js";
 import { createOpencodeClient } from "@opencode-ai/sdk";
 import { ToolRegistry as CoreRegistry } from "./tools/core/registry.js";
 import { LocalExecutor } from "./tools/executors/local.js";
@@ -66,8 +70,14 @@ const log = createLogger("plugin");
 interface McpToolSummary {
   serverName: string;
   toolName: string;
+  callName?: string;
   description?: string;
   params?: string[];
+}
+
+function getMcpToolDefinitionName(mcpToolDefs: any[], index: number): string | undefined {
+  const name = mcpToolDefs[index]?.function?.name;
+  return typeof name === "string" && name.length > 0 ? name : undefined;
 }
 
 export function buildAvailableToolsSystemMessage(
@@ -86,8 +96,15 @@ export function buildAvailableToolsSystemMessage(
   }
 
   if (mcpToolSummaries && mcpToolSummaries.length > 0) {
-    const servers = new Map<string, McpToolSummary[]>();
-    for (const s of mcpToolSummaries) {
+    const summariesWithCallNames = mcpToolSummaries.map((summary, index) => ({
+      ...summary,
+      callName: summary.callName
+        ?? getMcpToolDefinitionName(mcpToolDefs, index)
+        ?? namespaceMcpTool(summary.serverName, summary.toolName),
+    }));
+
+    const servers = new Map<string, Array<McpToolSummary & { callName: string }>>();
+    for (const s of summariesWithCallNames) {
       const list = servers.get(s.serverName) ?? [];
       list.push(s);
       servers.set(s.serverName, list);
@@ -103,7 +120,8 @@ export function buildAvailableToolsSystemMessage(
       lines.push(`Server: ${server}`);
       for (const t of tools) {
         const paramHint = t.params?.length ? ` (params: ${t.params.join(", ")})` : "";
-        lines.push(`  - ${t.toolName}${paramHint}${t.description ? " — " + t.description : ""}`);
+        const sourceHint = t.callName === t.toolName ? "" : ` (server: ${t.serverName}; tool: ${t.toolName})`;
+        lines.push(`  - ${t.callName}${paramHint}${t.description ? " — " + t.description : ""}${sourceHint}`);
       }
       lines.push("");
     }
@@ -1873,6 +1891,7 @@ export const CursorPlugin: Plugin = async ({ $, directory, worktree, client, ser
           mcpToolSummaries = tools.map((t) => ({
             serverName: t.serverName,
             toolName: t.name,
+            callName: namespaceMcpTool(t.serverName, t.name),
             description: t.description,
             params: t.inputSchema
               ? Object.keys((t.inputSchema as any).properties ?? {})

--- a/tests/unit/plugin-mcp-system-transform.test.ts
+++ b/tests/unit/plugin-mcp-system-transform.test.ts
@@ -12,7 +12,7 @@ describe("Plugin MCP system transform", () => {
     expect(systemMessage).toContain("skill_search -> search");
   });
 
-  it("includes mcptool Shell instructions when summaries provided", () => {
+  it("includes direct MCP tool call instructions when summaries provided", () => {
     const systemMessage = buildAvailableToolsSystemMessage(
       ["read", "write"],
       [],
@@ -37,15 +37,15 @@ describe("Plugin MCP system transform", () => {
       ],
     );
 
-    expect(systemMessage).toContain("mcptool call");
+    expect(systemMessage).toContain("direct tool calls");
+    expect(systemMessage).toContain("mcp__");
     expect(systemMessage).toContain("hybrid-memory");
     expect(systemMessage).toContain("memory_search");
     expect(systemMessage).toContain("memory_stats");
     expect(systemMessage).toContain("query, limit");
-    expect(systemMessage).toContain("Shell");
   });
 
-  it("includes multiple servers in Shell instructions", () => {
+  it("includes multiple servers in MCP tool instructions", () => {
     const systemMessage = buildAvailableToolsSystemMessage(
       [],
       [],

--- a/tests/unit/plugin-mcp-system-transform.test.ts
+++ b/tests/unit/plugin-mcp-system-transform.test.ts
@@ -39,10 +39,36 @@ describe("Plugin MCP system transform", () => {
 
     expect(systemMessage).toContain("direct tool calls");
     expect(systemMessage).toContain("mcp__");
+    expect(systemMessage).toContain("mcp__hybrid_memory__memory_search");
     expect(systemMessage).toContain("hybrid-memory");
     expect(systemMessage).toContain("memory_search");
     expect(systemMessage).toContain("memory_stats");
     expect(systemMessage).toContain("query, limit");
+  });
+
+  it("prints exact callable MCP tool names when server or tool names are sanitized", () => {
+    const systemMessage = buildAvailableToolsSystemMessage(
+      [],
+      [],
+      [
+        {
+          type: "function",
+          function: { name: "mcp__test_filesystem__list_directory" },
+        },
+      ],
+      [
+        {
+          serverName: "test-filesystem",
+          toolName: "list-directory",
+          description: "List dir",
+          params: ["path"],
+        },
+      ],
+    );
+
+    expect(systemMessage).toContain("mcp__test_filesystem__list_directory");
+    expect(systemMessage).toContain("server: test-filesystem");
+    expect(systemMessage).toContain("tool: list-directory");
   });
 
   it("includes multiple servers in MCP tool instructions", () => {


### PR DESCRIPTION
Stacked follow-up for #77.

This keeps the prompt-level approach from #77, but makes the system message print the exact callable MCP tool name instead of leaving the model to infer it from the raw server/tool names.

That matters for names like `hybrid-memory`, where the callable name is `mcp__hybrid_memory__...`, not `mcp__hybrid-memory__...`.

Changes:
- carry the computed MCP call name with the tool summary
- reuse the same namespacing helper used by the MCP bridge
- add a regression test for sanitized server/tool names

Verification:
- `npm run build`
- `npm test -- tests/unit/plugin-mcp-system-transform.test.ts tests/unit/mcp/tool-bridge.test.ts tests/unit/mcp/integration.test.ts`
- `npm test` (`606 pass`, `2 skip`, `0 fail`)

Rollback note: pre-#77 snapshot tag is `rollback/pre-pr77-mcp-direct-tools-2026-05-24` at `f3a07f8`; npm latest before these changes is `2.4.5`.
