### PR TITLE
 fix: register oc_* aliases for local tool hooks

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1815,6 +1815,11 @@ function buildToolHookEntries(registry: CoreRegistry, fallbackBaseDir?: string):
 
     entries[t.name] = createEntry(t.name);
 
+    const ocAlias = `oc_${t.id}`;
+    if (!entries[ocAlias]) {
+      entries[ocAlias] = createEntry(ocAlias);
+    }
+
     // Some agent variants emit "shell" instead of "bash".
     if (t.name === "bash" && !entries.shell) {
       entries.shell = createEntry("shell");

--- a/src/proxy/tool-loop.ts
+++ b/src/proxy/tool-loop.ts
@@ -37,6 +37,16 @@ const TOOL_NAME_ALIASES = new Map<string, string>([
   ["bashcommand", "bash"],
   ["runbash", "bash"],
   ["executebash", "bash"],
+  // edit/write aliases
+  ["ocedit", "edit"],
+  ["strreplace", "edit"],
+  ["replace", "edit"],
+  ["ocwrite", "write"],
+  ["writefile", "write"],
+  // read aliases
+  ["ocread", "read"],
+  // grep aliases
+  ["ocgrep", "grep"],
   // glob aliases
   ["findfiles", "glob"],
   ["searchfiles", "glob"],

--- a/tests/unit/plugin-tools-hook.test.ts
+++ b/tests/unit/plugin-tools-hook.test.ts
@@ -54,6 +54,9 @@ describe("Plugin tool hook", () => {
     expect(toolNames).toContain("read");
     expect(toolNames).toContain("write");
     expect(toolNames).toContain("edit");
+    expect(toolNames).toContain("oc_edit");
+    expect(toolNames).toContain("oc_write");
+    expect(toolNames).toContain("oc_read");
     expect(toolNames).not.toContain("grep");
     expect(toolNames).toContain("ls");
     expect(toolNames).toContain("glob");
@@ -155,7 +158,29 @@ describe("Plugin tool hook", () => {
     }
   });
 
-  it("pins non-config workspace per session and reuses it when later context loses worktree", async () => {
+
+
+  it("executes oc_edit alias the same as edit", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-oc-edit-"));
+    try {
+      const target = join(projectDir, "file.txt");
+      const hooks = await CursorPlugin(createMockInput(projectDir));
+      const { writeFileSync } = await import("fs");
+      writeFileSync(target, "hello world", "utf-8");
+
+      const out = await hooks.tool?.oc_edit?.execute(
+        { path: target, old_string: "hello", new_string: "hi" },
+        createToolContext(projectDir, projectDir),
+      );
+
+      expect(readFileSync(target, "utf-8")).toBe("hi world");
+      expect(out).toContain("edited successfully");
+    } finally {
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+ it("pins non-config workspace per session and reuses it when later context loses worktree", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-session-pin-project-"));
     const xdgConfigHome = mkdtempSync(join(tmpdir(), "plugin-hook-session-pin-xdg-"));
     const unexpectedDir = mkdtempSync(join(tmpdir(), "plugin-hook-session-pin-unexpected-"));


### PR DESCRIPTION
Fixes #83 

## Problem

System prompt instructs models to use `oc_edit`, but the tool hook only exposes `edit`.

## Changes

- Register `oc_${t.id}` alias for each local tool in `buildToolHookEntries` (same pattern as `bash` → `shell`)
- Add `ocedit`/`strreplace`/`ocwrite`/`ocread`/`ocgrep` aliases in `TOOL_NAME_ALIASES`

## Test plan

- [x] `bun test tests/unit/plugin-tools-hook.test.ts` — 8 pass
- [ ] Manual: OpenCode + `cursor-acp/auto`, ask for a small file edit, confirm `oc_edit` succeeds

## How to verify locally

```bash
git checkout fix/oc-tool-aliases
bun install
bun test tests/unit/plugin-tools-hook.test.ts
bun run build
ln -sf "$(pwd)/dist/plugin-entry.js" ~/.config/opencode/plugin/cursor-acp.js
# restart OpenCode, then:
opencode run "edit a file with a one-word change" --model cursor-acp/auto
```