### PR TITLE
feat: route Cursor AskQuestion tool calls to OpenCode's question tool

### DIFF
--- a/src/provider/tool-schema-compat.ts
+++ b/src/provider/tool-schema-compat.ts
@@ -3,6 +3,12 @@ import type { OpenAiToolCall } from "../proxy/tool-loop.js";
 type JsonRecord = Record<string, unknown>;
 
 const EDIT_COMPAT_REPAIR_ENABLED = process.env.CURSOR_ACP_EDIT_COMPAT_REPAIR !== "false";
+const QUESTION_COMPAT_REPAIR_ENABLED = process.env.CURSOR_ACP_QUESTION_COMPAT_REPAIR !== "false";
+
+// OpenCode's `question` tool caps option labels and the per-question header at
+// 30 characters (see opencode question schema). Cursor-style AskQuestion
+// payloads routinely exceed this, so we truncate when remapping.
+const QUESTION_LABEL_MAX = 30;
 
 const ARG_KEY_ALIASES = new Map<string, string>([
   ["filepath", "path"],
@@ -252,6 +258,10 @@ function resolveCanonicalArgKey(rawKey: string): string | null {
 
 function normalizeToolSpecificArgs(toolName: string, args: JsonRecord): JsonRecord {
   const normalizedToolName = toolName.toLowerCase();
+  if (normalizedToolName === "question" && QUESTION_COMPAT_REPAIR_ENABLED) {
+    return normalizeQuestionArgs(args);
+  }
+
   if (normalizedToolName === "bash") {
     const normalized: JsonRecord = { ...args };
     const normalizedCommand = normalizeBashCommand(normalized.command);
@@ -362,6 +372,102 @@ function normalizeToolSpecificArgs(toolName: string, args: JsonRecord): JsonReco
   }
 
   return repaired;
+}
+
+/**
+ * Maps a Cursor-style `AskQuestion` payload into OpenCode's `question` schema.
+ *
+ * Cursor emits:   { title?, questions: [{ id?, prompt, options: [{ id?, label }], allow_multiple? }] }
+ * OpenCode wants: { questions: [{ question, header(<=30), options: [{ label(<=30), description }], multiple?, custom? }] }
+ *
+ * The transform is idempotent: payloads already shaped for OpenCode pass through
+ * unchanged apart from defensive truncation of over-long labels/headers.
+ */
+function normalizeQuestionArgs(args: JsonRecord): JsonRecord {
+  if (!Array.isArray(args.questions)) {
+    return args;
+  }
+
+  const topTitle = typeof args.title === "string" ? args.title : undefined;
+
+  const questions = args.questions.map((rawQuestion) => {
+    if (!isRecord(rawQuestion)) {
+      return rawQuestion;
+    }
+
+    const question: JsonRecord = { ...rawQuestion };
+
+    // prompt/text -> question
+    if (typeof question.question !== "string") {
+      if (typeof question.prompt === "string") {
+        question.question = question.prompt;
+      } else if (typeof question.text === "string") {
+        question.question = question.text;
+      }
+    }
+    delete question.prompt;
+    delete question.text;
+
+    // header (<=30 chars). Prefer an explicit header, then the top-level title,
+    // then a truncation of the question itself so the field is never empty.
+    const headerSource =
+      typeof question.header === "string" && question.header.trim().length > 0
+        ? question.header
+        : topTitle ?? (typeof question.question === "string" ? question.question : "");
+    question.header = truncate(headerSource, QUESTION_LABEL_MAX);
+
+    // allow_multiple -> multiple
+    if (question.multiple === undefined && typeof question.allow_multiple === "boolean") {
+      question.multiple = question.allow_multiple;
+    }
+    delete question.allow_multiple;
+
+    if (Array.isArray(question.options)) {
+      question.options = question.options.map((rawOption) => {
+        if (typeof rawOption === "string") {
+          return { label: truncate(rawOption, QUESTION_LABEL_MAX), description: rawOption };
+        }
+        if (!isRecord(rawOption)) {
+          return rawOption;
+        }
+
+        const option: JsonRecord = { ...rawOption };
+        const fullLabel =
+          typeof option.label === "string"
+            ? option.label
+            : typeof option.title === "string"
+              ? option.title
+              : typeof option.text === "string"
+                ? option.text
+                : "";
+
+        // OpenCode requires a non-empty description; fall back to the full label.
+        if (typeof option.description !== "string" || option.description.trim().length === 0) {
+          option.description = fullLabel;
+        }
+        const labelSource = fullLabel.length > 0 ? fullLabel : String(option.description ?? "");
+        option.label = truncate(labelSource, QUESTION_LABEL_MAX);
+
+        // Cursor-only fields OpenCode does not understand.
+        delete option.id;
+        delete option.title;
+        delete option.text;
+        return option;
+      });
+    }
+
+    // Cursor scopes answers by per-question id; OpenCode keys by index/label.
+    delete question.id;
+    return question;
+  });
+
+  // OpenCode's `question` schema has no top-level title field.
+  return { questions };
+}
+
+function truncate(value: unknown, max: number): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  return text.length > max ? text.slice(0, max) : text;
 }
 
 function normalizeBashCommand(value: unknown): string | null {

--- a/src/proxy/tool-loop.ts
+++ b/src/proxy/tool-loop.ts
@@ -97,6 +97,12 @@ const TOOL_NAME_ALIASES = new Map<string, string>([
   ["mcp_skill", "skill_mcp"],
   ["runmcpskill", "skill_mcp"],
   ["invokeskillmcp", "skill_mcp"],
+  // question aliases (Cursor-trained models often emit AskQuestion / ask_user)
+  ["askquestion", "question"],
+  ["askuser", "question"],
+  ["askuserquestion", "question"],
+  ["askquestions", "question"],
+  ["promptuser", "question"],
 ]);
 
 export function extractAllowedToolNames(tools: Array<any>): Set<string> {

--- a/tests/unit/provider-tool-schema-compat.test.ts
+++ b/tests/unit/provider-tool-schema-compat.test.ts
@@ -45,6 +45,45 @@ function buildEditWriteSchemaMap(writeUsesFilePath = false): Map<string, unknown
   ]);
 }
 
+function buildQuestionSchemaMap(): Map<string, unknown> {
+  return new Map([
+    [
+      "question",
+      {
+        type: "object",
+        properties: {
+          questions: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                question: { type: "string" },
+                header: { type: "string" },
+                multiple: { type: "boolean" },
+                custom: { type: "boolean" },
+                options: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      label: { type: "string" },
+                      description: { type: "string" },
+                    },
+                    required: ["label", "description"],
+                  },
+                },
+              },
+              required: ["question", "header", "options"],
+            },
+          },
+        },
+        required: ["questions"],
+        additionalProperties: false,
+      },
+    ],
+  ]);
+}
+
 function editToolCall(args: Record<string, unknown>, id = "c_edit"): OpenAiToolCall {
   return {
     id,
@@ -962,6 +1001,111 @@ describe("tool schema compatibility", () => {
     expect(args.path).toBe("/tmp/b.txt");
     expect(args.content).toBe("hello");
     expect(args.new_string).toBeUndefined();
+    expect(result.validation.ok).toBe(true);
+  });
+
+  it("maps a Cursor AskQuestion payload onto the OpenCode question schema", () => {
+    const longOption = "Apply the recommended fix and rerun the test suite";
+    const result = applyToolSchemaCompat(
+      {
+        id: "q1",
+        type: "function",
+        function: {
+          name: "question",
+          arguments: JSON.stringify({
+            title: "How should we proceed with the migration?",
+            questions: [
+              {
+                id: "step",
+                prompt: "Which approach do you want?",
+                allow_multiple: true,
+                options: [
+                  { id: "a", label: longOption },
+                  { id: "b", label: "Skip" },
+                ],
+              },
+            ],
+          }),
+        },
+      },
+      buildQuestionSchemaMap(),
+    );
+
+    const args = JSON.parse(result.toolCall.function.arguments);
+    expect(args.title).toBeUndefined();
+    expect(args.questions).toHaveLength(1);
+
+    const q = args.questions[0];
+    expect(q.question).toBe("Which approach do you want?");
+    expect(q.prompt).toBeUndefined();
+    expect(q.id).toBeUndefined();
+    expect(q.allow_multiple).toBeUndefined();
+    expect(q.multiple).toBe(true);
+    expect(q.header.length).toBeLessThanOrEqual(30);
+    expect(q.header).toBe("How should we proceed with the".slice(0, 30));
+
+    expect(q.options[0].label.length).toBeLessThanOrEqual(30);
+    expect(q.options[0].description).toBe(longOption);
+    expect(q.options[0].id).toBeUndefined();
+    expect(q.options[1].label).toBe("Skip");
+    expect(q.options[1].description).toBe("Skip");
+
+    expect(result.validation.ok).toBe(true);
+  });
+
+  it("leaves an already OpenCode-shaped question payload valid", () => {
+    const result = applyToolSchemaCompat(
+      {
+        id: "q2",
+        type: "function",
+        function: {
+          name: "question",
+          arguments: JSON.stringify({
+            questions: [
+              {
+                question: "Pick one",
+                header: "Pick",
+                multiple: false,
+                options: [{ label: "Yes", description: "Proceed now" }],
+              },
+            ],
+          }),
+        },
+      },
+      buildQuestionSchemaMap(),
+    );
+
+    const q = JSON.parse(result.toolCall.function.arguments).questions[0];
+    expect(q.question).toBe("Pick one");
+    expect(q.header).toBe("Pick");
+    expect(q.options[0].label).toBe("Yes");
+    expect(q.options[0].description).toBe("Proceed now");
+    expect(result.validation.ok).toBe(true);
+  });
+
+  it("synthesizes a header from the question when none is provided", () => {
+    const result = applyToolSchemaCompat(
+      {
+        id: "q3",
+        type: "function",
+        function: {
+          name: "question",
+          arguments: JSON.stringify({
+            questions: [
+              {
+                prompt: "Do you want to continue with the deployment to production?",
+                options: [{ label: "Confirm" }],
+              },
+            ],
+          }),
+        },
+      },
+      buildQuestionSchemaMap(),
+    );
+
+    const q = JSON.parse(result.toolCall.function.arguments).questions[0];
+    expect(q.header.length).toBeLessThanOrEqual(30);
+    expect(q.header.length).toBeGreaterThan(0);
     expect(result.validation.ok).toBe(true);
   });
 });

--- a/tests/unit/proxy/tool-loop.test.ts
+++ b/tests/unit/proxy/tool-loop.test.ts
@@ -297,6 +297,40 @@ describe("proxy/tool-loop", () => {
     expect(result.toolCall?.function.name).toBe("skill_mcp");
   });
 
+  it("maps askQuestion alias to allowed question tool name", () => {
+    const event: any = {
+      type: "tool_call",
+      call_id: "call_question_alias",
+      name: "askQuestion",
+      tool_call: {
+        askQuestion: {
+          args: { questions: [{ prompt: "Proceed?", options: [{ label: "Yes" }] }] },
+        },
+      },
+    };
+
+    const result = extractOpenAiToolCall(event, new Set(["question"]));
+    expect(result.action).toBe("intercept");
+    expect(result.toolCall?.function.name).toBe("question");
+  });
+
+  it("passes askQuestion through when question tool is not allowed", () => {
+    const event: any = {
+      type: "tool_call",
+      call_id: "call_question_passthrough",
+      name: "askQuestion",
+      tool_call: {
+        askQuestion: {
+          args: { questions: [{ prompt: "Proceed?", options: [{ label: "Yes" }] }] },
+        },
+      },
+    };
+
+    const result = extractOpenAiToolCall(event, new Set(["bash"]));
+    expect(result.action).toBe("passthrough");
+    expect(result.passthroughName).toBe("askQuestion");
+  });
+
   it("builds valid non-stream tool call response", () => {
     const response = createToolCallCompletionResponse(
       { id: "resp-1", created: 123, model: "cursor-acp/auto" },


### PR DESCRIPTION
# feat: route Cursor `AskQuestion` tool calls to OpenCode's `question` tool

## Problem

Cursor-trained models (Claude/GPT served through `cursor-agent`) frequently emit a
tool call named `askQuestion` / `AskQuestion` — the name they learned from Cursor's
own system prompt. OpenCode's interactive tool is named `question`, so OpenCode
rejects the call with:

```
Model tried to call unavailable tool 'askQuestion'.
Available tools: ... question ...
```

Because the call never resolves, the model retries the same invalid name and the
session spins in an infinite loop (the user sees repeated "skipped the choice"
turns and the question dialog never appears).

A plain rename is not enough: OpenCode's `question` schema differs from Cursor's
`AskQuestion` payload, so the renamed call would then fail argument validation
and keep looping.

## Fix

Two small, additive changes that follow existing patterns in the codebase
(`TOOL_NAME_ALIASES`, `ARG_KEY_ALIASES`, `tryRerouteEditToWrite`):

1. **`src/proxy/tool-loop.ts`** — add `question` aliases to `TOOL_NAME_ALIASES`
   (`askquestion`, `askuser`, `askuserquestion`, `askquestions`, `promptuser`).
   The alias only resolves when the host actually advertises a `question` tool;
   otherwise the call still passes through to `cursor-agent` unchanged.

2. **`src/provider/tool-schema-compat.ts`** — add a `question` branch to
   `normalizeToolSpecificArgs` that remaps the Cursor payload onto OpenCode's
   schema:

   | Cursor `AskQuestion`            | OpenCode `question`                     |
   | ------------------------------- | --------------------------------------- |
   | `questions[].prompt`            | `questions[].question`                  |
   | top-level `title` / question text | `questions[].header` (truncated ≤30)  |
   | `options[].label` (long)        | `options[].description` (full text)     |
   | `options[].label`               | `options[].label` (truncated ≤30)       |
   | `questions[].allow_multiple`    | `questions[].multiple`                  |
   | `questions[].id`, `options[].id`| dropped (OpenCode keys by index/label)  |

   OpenCode caps option labels and the per-question header at 30 chars, so the
   transform truncates and preserves the full text in `description`. The mapping
   is idempotent — payloads already shaped for OpenCode pass through unchanged.

   Gated behind `CURSOR_ACP_QUESTION_COMPAT_REPAIR` (default on), matching the
   existing `CURSOR_ACP_EDIT_COMPAT_REPAIR` escape hatch.

## Tests

- `tests/unit/proxy/tool-loop.test.ts`: `askQuestion` → `question` aliasing, and
  passthrough when `question` is not in the allowlist.
- `tests/unit/provider-tool-schema-compat.test.ts`: full Cursor→OpenCode payload
  mapping, idempotency for already-shaped payloads, and header synthesis.

All unit tests pass (`bun test tests/unit` → 443 pass, 1 skip, 0 fail) and
`bun run build` succeeds.

## Notes

This is the proxy-layer counterpart to the prompt-level guidance some users add
("the question tool is named `question`, never call `askQuestion`"). Handling it
in the boundary means the native OpenCode question dialog works even when the
model insists on Cursor's vocabulary.
