### PR TITLE
Preserve legacy fallback for SDK backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ No prompt limits. No broken streams. Full thinking + tool support in OpenCode. Y
 
 ## Requirements
 
-- **Node.js >= 20** (required for the SDK runner process)
-- **CURSOR_API_KEY** environment variable (from [cursor.com/settings](https://cursor.com/settings))
+- **Bun** for the OpenCode plugin runtime.
+- **Node.js >= 20** when using the SDK backend (`CURSOR_ACP_BACKEND=sdk` or automatic SDK fallback).
+- Existing `cursor-agent login` users can keep using that flow when the `cursor-agent` binary is available.
 
 ## Installation
 
@@ -24,7 +25,7 @@ cd opencode-cursor
 ./scripts/install-plugin.sh
 ```
 
-Set your API key:
+If you are using the SDK backend, set your API key:
 ```bash
 export CURSOR_API_KEY=<your-api-key>
 ```
@@ -148,7 +149,9 @@ Add `"cursor-acp"` to the `plugin` array and reuse the provider block from Optio
 
 ## Authentication
 
-The plugin supports three methods to provide your Cursor API key, in priority order:
+By default, `CURSOR_ACP_BACKEND=auto` preserves existing `cursor-agent` behavior when the `cursor-agent` binary is available. The SDK backend is used only when you set `CURSOR_ACP_BACKEND=sdk` or when `auto` cannot find `cursor-agent` and a real Cursor API key is configured.
+
+For SDK mode, the plugin supports three methods to provide your Cursor API key, in priority order:
 
 ### Option 1: Environment Variable (Highest Priority)
 
@@ -187,7 +190,7 @@ Set the API key directly in your `opencode.json` provider options:
 }
 ```
 
-**Get your API key from [cursor.com/settings](https://cursor.com/settings) under API Keys.**
+Do not use the historical `cursor-agent` placeholder as an SDK key; it is only kept for legacy OpenCode provider compatibility. Get a real API key from [cursor.com/settings](https://cursor.com/settings) under API Keys.
 
 ## Usage
 
@@ -240,9 +243,9 @@ flowchart TB
     MCPTOOL --> RUNNER
 ```
 
-**How it works:** A persistent Node.js child process (`scripts/sdk-runner.mjs`) runs `@cursor/sdk` on behalf of the proxy. This replaces the old `cursor-agent` binary (removed in Cursor >= 0.43). The SDK runs in a separate Node process because its ConnectRPC/HTTP2 stack hangs inside OpenCode's embedded Bun runtime. The runner emits NDJSON `StreamJsonEvent` objects, which the proxy converts to OpenAI-compatible SSE format. Note: per-request latency (~6s) is dominated by the SDK's `Agent.create` + `send` calls themselves.
+**How it works:** The proxy uses a dual-backend runtime. In `auto` mode it prefers the existing `cursor-agent` binary when available, preserving current workflows. If `cursor-agent` is unavailable and a real Cursor API key is configured, or if `CURSOR_ACP_BACKEND=sdk` is set, a persistent Node.js child process (`scripts/sdk-runner.mjs`) runs `@cursor/sdk` on behalf of the proxy. The SDK runs in a separate Node process because its ConnectRPC/HTTP2 stack hangs inside OpenCode's embedded Bun runtime. The runner emits NDJSON `StreamJsonEvent` objects, which the proxy converts to OpenAI-compatible SSE format.
 
-By default, the Agent runs in isolated mode (`settingSources: []`), loading no rules, skills, or MCP servers from the Cursor environment. This avoids duplicate instructions between Cursor and OpenCode and reduces request latency. To restore the previous behavior (loading all Cursor env settings), set `CURSOR_ACP_SETTING_SOURCES=all`. You can also specify a subset: `CURSOR_ACP_SETTING_SOURCES=user,project` loads only user and project rules.
+By default, the SDK Agent runs in isolated mode (`settingSources: []`), loading no rules, skills, or MCP servers from the Cursor environment. This avoids duplicate instructions between Cursor and OpenCode and keeps OpenCode-owned MCP execution as the default. To load Cursor environment settings in SDK mode, set `CURSOR_ACP_SETTING_SOURCES=all`. You can also specify a subset: `CURSOR_ACP_SETTING_SOURCES=user,project` loads only user and project rules.
 
 Default tool-loop mode: `CURSOR_ACP_TOOL_LOOP_MODE=opencode`. Details: [docs/architecture/runtime-tool-loop.md](docs/architecture/runtime-tool-loop.md).
 
@@ -265,7 +268,7 @@ THERE is currently not a single perfect plugin for cursor in opencode, my advice
 
 ## Troubleshooting
 
-- `CURSOR_API_KEY not set` → Set `export CURSOR_API_KEY=<your-api-key>` (get it from [cursor.com/settings](https://cursor.com/settings))
+- `CURSOR_API_KEY not set` in SDK mode → Set `export CURSOR_API_KEY=<your-api-key>` (get it from [cursor.com/settings](https://cursor.com/settings)) or switch back to `CURSOR_ACP_BACKEND=auto` with a working `cursor-agent`.
 - Model not responding → Verify your API key is valid and you have quota
 - Quota exceeded → [cursor.com/settings](https://cursor.com/settings)
 - Proxy not starting → Ensure Node.js is in your PATH and port 32124 is available

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
         "@types/node": "^22.0.0",
         "typescript": "^5.8.0"
       },
+      "optionalDependencies": {
+        "@cursor/sdk": "^1.0.18"
+      },
       "peerDependencies": {
         "@opencode-ai/sdk": "^1.0.0",
         "bun-types": "^1.1.0"
@@ -74,6 +77,172 @@
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "optional": true
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.18.tgz",
+      "integrity": "sha512-ha5EGHliMuTNuAqnPHzKFNnND4y6erddTqtxwIt9/p8ER+QsmMoRcP38PwA2sXfZnGvIBiozveBZqa4XwUddCw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "sqlite3": "^5.1.7",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.18",
+        "@cursor/sdk-darwin-x64": "1.0.18",
+        "@cursor/sdk-linux-arm64": "1.0.18",
+        "@cursor/sdk-linux-x64": "1.0.18",
+        "@cursor/sdk-win32-x64": "1.0.18"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.18.tgz",
+      "integrity": "sha512-gXfNz+n3uf2hWCUcSdU/gBYT7TFlWwJjZAAjXFzBJ3jGu+l7ShQRa9QI2sEKvPNRtUMC/18EcQ26ks1o261Bnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.18.tgz",
+      "integrity": "sha512-nzcPqCvPPnYsuz21olPgandVgGUzDZkHN4cUls4ukm7mddp6XqujFJv8lh9qKmVefl0/3UL2R6GFANggjwifnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.18.tgz",
+      "integrity": "sha512-MJyhVryN+0czP48SgMak/KA9xGneQ/gdsnDk1ZTJF+LemaFc+Tv7P1GT80h+3JBfu69kPyIX4epJVjroTMoFEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.18.tgz",
+      "integrity": "sha512-IaJqcKtXxtQEdPxivQjDWbvynw3UX31V8RdagcZ6RgHOo+B/i/P95D8svSNC4V9nbTHwVbNGfIDQ5S64gMS2hg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "rg": "bin/rg"
+      }
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.18.tgz",
+      "integrity": "sha512-iqcGt1l/3xgnaT+PotY3237oyK3VnOZHtjUxSRP3Q7ahjaqsZVTnCwwljj+nal8ouvXidBHnxQLqGMSC2G6LTg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "rg": "bin/rg.exe"
+      }
+    },
+    "node_modules/@cursor/sdk/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.11",
@@ -127,6 +296,32 @@
         }
       }
     },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@opencode-ai/plugin": {
       "version": "1.1.53",
       "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.1.53.tgz",
@@ -167,6 +362,33 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -185,6 +407,13 @@
         "node": ">= 20"
       }
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -196,6 +425,46 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ai": {
@@ -261,6 +530,78 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
@@ -285,6 +626,42 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/bun-types": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.9.tgz",
@@ -302,6 +679,36 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -332,6 +739,50 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -421,6 +872,39 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -428,6 +912,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -450,6 +944,13 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -458,6 +959,56 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -523,6 +1074,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -608,6 +1169,13 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -647,6 +1215,33 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -654,6 +1249,50 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/get-intrinsic": {
@@ -693,6 +1332,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -705,6 +1373,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -716,6 +1391,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -738,6 +1420,13 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -758,6 +1447,45 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -774,11 +1502,78 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -797,6 +1592,23 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
@@ -836,6 +1648,57 @@
       "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -892,11 +1755,171 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -905,6 +1928,84 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -949,6 +2050,22 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -956,6 +2073,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -986,6 +2113,55 @@
         "node": ">=16.20.0"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -997,6 +2173,17 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -1038,6 +2225,37 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -1045,6 +2263,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/router": {
@@ -1063,11 +2308,45 @@
         "node": ">= 18"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -1113,6 +2392,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -1213,6 +2499,149 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks/node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1220,6 +2649,54 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
@@ -1237,6 +2714,82 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1244,6 +2797,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -1274,11 +2840,44 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1288,6 +2887,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -1313,11 +2919,28 @@
         "node": ">= 8"
       }
     },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "bun test",
     "test:unit": "bun test tests/unit",
     "test:integration": "bun test tests/integration",
-    "test:ci:unit": "bun test tests/tools/defaults.test.ts tests/tools/executor-chain.test.ts tests/tools/sdk-executor.test.ts tests/tools/mcp-executor.test.ts tests/tools/skills.test.ts tests/tools/registry.test.ts tests/unit/cli/opencode-cursor.test.ts tests/unit/cli/model-discovery.test.ts tests/unit/proxy/prompt-builder.test.ts tests/unit/proxy/tool-loop.test.ts tests/unit/provider-boundary.test.ts tests/unit/provider-runtime-interception.test.ts tests/unit/provider-tool-schema-compat.test.ts tests/unit/provider-tool-loop-guard.test.ts tests/unit/plugin.test.ts tests/unit/plugin-tools-hook.test.ts tests/unit/plugin-tool-resolution.test.ts tests/unit/plugin-config.test.ts tests/unit/plugin-stream-extraction.test.ts tests/unit/auth.test.ts tests/unit/streaming/line-buffer.test.ts tests/unit/streaming/parser.test.ts tests/unit/streaming/types.test.ts tests/unit/streaming/delta-tracker.test.ts tests/unit/streaming/openai-sse.test.ts tests/unit/streaming/ai-sdk-parts.test.ts tests/competitive/edge.test.ts",
+    "test:ci:unit": "bun test tests/tools/defaults.test.ts tests/tools/executor-chain.test.ts tests/tools/sdk-executor.test.ts tests/tools/mcp-executor.test.ts tests/tools/skills.test.ts tests/tools/registry.test.ts tests/unit/cli/opencode-cursor.test.ts tests/unit/cli/model-discovery.test.ts tests/unit/models/discovery.test.ts tests/unit/proxy/prompt-builder.test.ts tests/unit/proxy/tool-loop.test.ts tests/unit/provider-backend.test.ts tests/unit/provider-boundary.test.ts tests/unit/provider-runtime-interception.test.ts tests/unit/provider-tool-schema-compat.test.ts tests/unit/provider-tool-loop-guard.test.ts tests/unit/mcp/tool-bridge.test.ts tests/unit/sdk-child.test.ts tests/unit/sdk-runner.test.ts tests/unit/plugin.test.ts tests/unit/plugin-tools-hook.test.ts tests/unit/plugin-tool-resolution.test.ts tests/unit/plugin-config.test.ts tests/unit/plugin-stream-extraction.test.ts tests/unit/auth.test.ts tests/unit/streaming/line-buffer.test.ts tests/unit/streaming/parser.test.ts tests/unit/streaming/types.test.ts tests/unit/streaming/delta-tracker.test.ts tests/unit/streaming/openai-sse.test.ts tests/unit/streaming/ai-sdk-parts.test.ts tests/competitive/edge.test.ts",
     "test:ci:integration": "bun test tests/integration/comprehensive.test.ts tests/integration/tools-router.integration.test.ts tests/integration/stream-router.integration.test.ts tests/integration/opencode-loop.integration.test.ts",
     "check:pricing": "bun run scripts/check-cursor-pricing-coverage.ts",
     "check:pricing:fixture": "bun run scripts/check-cursor-pricing-coverage.ts --models-file tests/fixtures/cursor-pricing-models.txt --skip-doc-fetch",
@@ -41,12 +41,14 @@
     "scripts/sdk-runner.mjs"
   ],
   "dependencies": {
-    "@cursor/sdk": "^1.0.18",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "@opencode-ai/plugin": "1.1.53",
     "@opencode-ai/sdk": "1.1.53",
     "ai": "^6.0.55",
     "strip-ansi": "^7.1.0"
+  },
+  "optionalDependencies": {
+    "@cursor/sdk": "^1.0.18"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/scripts/install-plugin.sh
+++ b/scripts/install-plugin.sh
@@ -27,25 +27,24 @@ else
   npm install
 fi
 
+echo ""
+echo "Building plugin..."
+if command -v bun &> /dev/null; then
+  bun run build
+else
+  npm run build
+fi
+
 # Create plugin directory
-PLUGIN_DIR="${HOME}/.config/opencode/plugins"
+PLUGIN_DIR="${HOME}/.config/opencode/plugin"
 mkdir -p "$PLUGIN_DIR"
 echo "Created plugin directory: $PLUGIN_DIR"
 
-# Write plugin wrapper
-PLUGIN_FILE="$PLUGIN_DIR/cursor-acp.ts"
+# Write plugin symlink after build succeeds
+PLUGIN_FILE="$PLUGIN_DIR/cursor-acp.js"
 echo ""
-echo "Writing plugin wrapper to: $PLUGIN_FILE"
-cat > "$PLUGIN_FILE" << EOF
-export { default } from "$REPO_ROOT/src/plugin-entry.ts"
-EOF
-
-# Clean up old versions
-OLD_PLUGIN_JS="${HOME}/.config/opencode/plugin/cursor-acp.js"
-if [ -f "$OLD_PLUGIN_JS" ]; then
-  echo "Removing old plugin version: $OLD_PLUGIN_JS"
-  rm -f "$OLD_PLUGIN_JS"
-fi
+echo "Linking plugin entrypoint to: $PLUGIN_FILE"
+ln -sfn "$REPO_ROOT/dist/plugin-entry.js" "$PLUGIN_FILE"
 
 # Validate opencode.json
 OPENCODE_CONFIG="${HOME}/.config/opencode/opencode.json"
@@ -62,19 +61,9 @@ if [ -f "$OPENCODE_CONFIG" ]; then
     } catch { process.stdout.write("no"); }
   ' "$OPENCODE_CONFIG")
   if [ "$IN_PLUGIN_ARRAY" = "yes" ]; then
-    echo ""
-    echo "WARNING: Your opencode.json contains 'cursor-acp' in the 'plugin' array."
-    echo "This causes OpenCode to try to install a third-party npm package instead of using this plugin."
-    echo ""
-    echo "Please manually edit $OPENCODE_CONFIG and:"
-    echo "  1. Remove 'cursor-acp' from the 'plugin' array"
-    echo "  2. Keep the 'provider' section with 'cursor-acp' intact"
-    echo ""
-    echo "Example fix:"
-    echo '  Remove the entry (or the whole "plugin" key if it becomes empty):'
-    echo '  "provider": {'
-    echo '    "cursor-acp": { ... }  // Keep this'
-    echo '  }'
+    echo "Found 'cursor-acp' in the plugin array."
+  else
+    echo "Reminder: add 'cursor-acp' to the plugin array if this is a new source install."
   fi
 fi
 
@@ -82,7 +71,10 @@ fi
 echo ""
 echo "Installation complete!"
 echo ""
-echo "IMPORTANT: Set the CURSOR_API_KEY environment variable:"
+echo "Existing cursor-agent users can continue with:"
+echo "  cursor-agent login"
+echo ""
+echo "For SDK mode or SDK fallback, set a real Cursor API key:"
 echo "  export CURSOR_API_KEY=<your-api-key>"
 echo ""
 echo "Get your API key from: https://cursor.com/settings"

--- a/scripts/sdk-runner.mjs
+++ b/scripts/sdk-runner.mjs
@@ -30,6 +30,8 @@
  * Lifecycle: reads stdin indefinitely; on EOF, disposes agents and exits 0.
  */
 
+import { pathToFileURL } from "node:url";
+
 // Import Agent and Cursor dynamically after API key check to accelerate boot time
 let Agent;
 let Cursor;
@@ -54,7 +56,12 @@ const SETTING_SOURCES = (() => {
 // pollute our NDJSON protocol. Redirect any stdout writes that don't come from
 // our emit helpers to stderr, and keep a private handle to the real stdout.
 const protocolWrite = process.stdout.write.bind(process.stdout);
-process.stdout.write = (chunk, ...args) => process.stderr.write(chunk, ...args);
+const RUNNING_AS_MAIN = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+if (RUNNING_AS_MAIN) {
+  process.stdout.write = (chunk, ...args) => process.stderr.write(chunk, ...args);
+}
 
 /**
  * Write a line to the real (protocol) stdout.
@@ -68,7 +75,13 @@ function writeProtocolLine(line) {
 /**
  * Convert SDK message to StreamJsonEvent (portable copy from sdk-child.ts).
  */
-function sdkMessageToStreamJson(msg) {
+export function namespaceMcpTool(serverName, toolName) {
+  const sanitizedServer = String(serverName).replace(/[^a-zA-Z0-9]/g, "_");
+  const sanitizedTool = String(toolName).replace(/[^a-zA-Z0-9]/g, "_");
+  return `mcp__${sanitizedServer}__${sanitizedTool}`;
+}
+
+export function sdkMessageToStreamJson(msg) {
   switch (msg?.type) {
     case "assistant": {
       const content = msg.message?.content ?? [];
@@ -105,7 +118,7 @@ function sdkMessageToStreamJson(msg) {
         const provider = args.providerIdentifier;
         const toolName = args.toolName;
         if (provider && toolName) {
-          name = `mcp__${provider}__${toolName}`;
+          name = namespaceMcpTool(provider, toolName);
           args = args.args ?? {};
           console.error(`[sdk-runner] Remapped mcp tool call -> ${name}`);
         } else {
@@ -391,7 +404,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(`[sdk-runner] Unhandled error in main:`, err);
-  process.exit(1);
-});
+if (RUNNING_AS_MAIN) {
+  main().catch((err) => {
+    console.error(`[sdk-runner] Unhandled error in main:`, err);
+    process.exit(1);
+  });
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -19,6 +19,14 @@ export interface AuthResult {
   error?: string;
 }
 
+export interface ResolveSdkApiKeyInput {
+  env?: Pick<NodeJS.ProcessEnv, "CURSOR_API_KEY">;
+  storedApiKey?: string;
+  authorizationHeader?: string | null;
+}
+
+const PLACEHOLDER_API_KEYS = new Set(["cursor-agent"]);
+
 function getHomeDir(): string {
   const override = process.env.CURSOR_ACP_HOME_DIR;
   if (override && override.length > 0) {
@@ -83,6 +91,35 @@ export function verifyCursorAuth(): boolean {
 
   log.debug("No auth found (no CURSOR_API_KEY, no auth file)", { checkedPaths: possiblePaths });
   return false;
+}
+
+export function isUsableSdkApiKey(value: string | undefined | null): value is string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  return !PLACEHOLDER_API_KEYS.has(trimmed.toLowerCase());
+}
+
+export function normalizeAuthorizationHeader(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const bearerMatch = /^bearer\s+(.+)$/i.exec(trimmed);
+  return bearerMatch?.[1]?.trim() ?? trimmed;
+}
+
+export function resolveSdkApiKey(input: ResolveSdkApiKeyInput): string | undefined {
+  const candidates = [
+    input.env?.CURSOR_API_KEY,
+    input.storedApiKey,
+    normalizeAuthorizationHeader(input.authorizationHeader),
+  ];
+
+  return candidates.find(isUsableSdkApiKey)?.trim();
 }
 
 /**

--- a/src/cli/opencode-cursor.ts
+++ b/src/cli/opencode-cursor.ts
@@ -20,6 +20,8 @@ import {
   fallbackModels,
 } from "./model-discovery.js";
 import { resolveCursorAgentBinary } from "../utils/binary.js";
+import { getPossibleAuthPaths, isUsableSdkApiKey } from "../auth.js";
+import { parseCursorBackendPreference } from "../provider/backend.js";
 import { groupCursorModels, mergeCursorModelEntries } from "../models/variants.js";
 import type { DiscoveredModel } from "./model-discovery.js";
 
@@ -56,6 +58,11 @@ type StatusResult = {
   };
   aiSdk: {
     installed: boolean;
+  };
+  auth: {
+    legacyCursorAuthFile: boolean;
+    sdkApiKey: boolean;
+    sdkApiKeySource?: "CURSOR_API_KEY" | "provider.options.apiKey";
   };
 };
 
@@ -118,6 +125,67 @@ export function checkCursorAgentLogin(): CheckResult {
       warning: true,
     };
   }
+}
+
+function getProviderApiKey(config: unknown): string | undefined {
+  const provider = (config as any)?.provider?.[PROVIDER_ID];
+  const apiKey = provider?.options?.apiKey;
+  return typeof apiKey === "string" ? apiKey : undefined;
+}
+
+function resolveCliSdkAuthSource(config: unknown): StatusResult["auth"]["sdkApiKeySource"] | undefined {
+  if (isUsableSdkApiKey(process.env.CURSOR_API_KEY)) {
+    return "CURSOR_API_KEY";
+  }
+  if (isUsableSdkApiKey(getProviderApiKey(config))) {
+    return "provider.options.apiKey";
+  }
+  return undefined;
+}
+
+function checkSdkApiKey(config: unknown): CheckResult {
+  const source = resolveCliSdkAuthSource(config);
+  if (source) {
+    return {
+      name: "Cursor SDK API key",
+      passed: true,
+      message: `available via ${source}`,
+    };
+  }
+
+  const backend = parseCursorBackendPreference(process.env.CURSOR_ACP_BACKEND).preference;
+  return {
+    name: "Cursor SDK API key",
+    passed: false,
+    warning: backend !== "sdk",
+    message: backend === "sdk"
+      ? "not configured - required for CURSOR_ACP_BACKEND=sdk"
+      : "not configured - required only for CURSOR_ACP_BACKEND=sdk or when cursor-agent is unavailable",
+  };
+}
+
+function adjustCursorAgentCheckForBackend(
+  check: CheckResult,
+  config: unknown,
+): CheckResult {
+  if (check.passed) {
+    return check;
+  }
+
+  const backend = parseCursorBackendPreference(process.env.CURSOR_ACP_BACKEND).preference;
+  const sdkSource = resolveCliSdkAuthSource(config);
+  const sdkCanHandleRequest = backend === "sdk" || (backend === "auto" && sdkSource);
+  if (!sdkCanHandleRequest) {
+    return check;
+  }
+
+  return {
+    ...check,
+    warning: true,
+    message: sdkSource
+      ? `${check.message}; SDK backend can be used via ${sdkSource}`
+      : `${check.message}; SDK backend selected but no SDK API key is configured`,
+  };
 }
 
 function checkOpenCode(): CheckResult {
@@ -230,8 +298,9 @@ export function runDoctorChecks(configPath: string, pluginPath: string): CheckRe
   }
   return [
     checkBun(),
-    checkCursorAgent(),
+    adjustCursorAgentCheckForBackend(checkCursorAgent(), config),
     checkCursorAgentLogin(),
+    checkSdkApiKey(config),
     checkOpenCode(),
     checkPluginFile(pluginPath, config),
     checkProviderConfig(configPath),
@@ -793,6 +862,8 @@ export function getStatusResult(configPath: string, pluginPath: string): StatusR
   const opencodeDir = dirname(configPath);
   const sdkPath = join(opencodeDir, "node_modules", "@ai-sdk", "openai-compatible");
   const aiSdkInstalled = existsSync(sdkPath);
+  const sdkApiKeySource = resolveCliSdkAuthSource(config);
+  const legacyCursorAuthFile = getPossibleAuthPaths().some((authPath) => existsSync(authPath));
 
   let installMethod: "symlink" | "npm-direct" | "none" = "none";
   if (pluginType !== "missing") {
@@ -817,6 +888,11 @@ export function getStatusResult(configPath: string, pluginPath: string): StatusR
     },
     aiSdk: {
       installed: aiSdkInstalled,
+    },
+    auth: {
+      legacyCursorAuthFile,
+      sdkApiKey: sdkApiKeySource !== undefined,
+      sdkApiKeySource,
     },
   };
 }
@@ -962,6 +1038,13 @@ function commandStatus(options: Options) {
   console.log("");
   console.log("AI SDK");
   console.log(`  @ai-sdk/openai-compatible: ${result.aiSdk.installed ? "installed" : "not installed"}`);
+
+  console.log("");
+  console.log("Authentication");
+  console.log(`  Legacy cursor-agent auth file: ${result.auth.legacyCursorAuthFile ? "found" : "not found"}`);
+  console.log(
+    `  Cursor SDK API key: ${result.auth.sdkApiKey ? `found via ${result.auth.sdkApiKeySource}` : "not configured"}`,
+  );
 }
 
 function commandDoctor(options: Options) {

--- a/src/client/sdk-child.ts
+++ b/src/client/sdk-child.ts
@@ -46,17 +46,31 @@ function resolveNodeBinary(): string {
  * Resolve the path to sdk-runner.mjs, handling both src/ (dev) and dist/ (built) contexts.
  * Returns the absolute path or throws if not found.
  */
-function resolveRunnerPath(): string {
-  const currentFile = fileURLToPath(import.meta.url);
+export function resolveRunnerPath(
+  currentFile: string = fileURLToPath(import.meta.url),
+  checkExists: (path: string) => boolean = existsSync,
+  env: Pick<NodeJS.ProcessEnv, "CURSOR_ACP_SDK_RUNNER_PATH"> = process.env,
+): string {
+  const override = env.CURSOR_ACP_SDK_RUNNER_PATH?.trim();
+  if (override) {
+    if (checkExists(override)) {
+      return override;
+    }
+    throw new Error(`CURSOR_ACP_SDK_RUNNER_PATH does not exist: ${override}`);
+  }
+
   const currentDir = dirname(currentFile);
 
-  // Candidates: ../../scripts/sdk-runner.mjs from both src/client/ and dist/client/
   const candidates = [
+    // Source layout: src/client/sdk-child.ts -> scripts/sdk-runner.mjs.
+    // Non-bundled dist layout: dist/client/sdk-child.js -> scripts/sdk-runner.mjs.
     resolve(currentDir, "../../scripts/sdk-runner.mjs"),
+    // Bundled package layout: dist/plugin-entry.js -> scripts/sdk-runner.mjs.
+    resolve(currentDir, "../scripts/sdk-runner.mjs"),
   ];
 
   for (const candidate of candidates) {
-    if (existsSync(candidate)) {
+    if (checkExists(candidate)) {
       return candidate;
     }
   }
@@ -278,6 +292,10 @@ class SdkRunnerSingleton {
 }
 
 const singleton = new SdkRunnerSingleton();
+
+export function stopSdkRunner(): void {
+  singleton.kill();
+}
 
 // ─── BUN-compatible child ──────────────────────────────────────────────────
 

--- a/src/models/discovery.ts
+++ b/src/models/discovery.ts
@@ -1,5 +1,8 @@
 import type { ModelInfo, DiscoveryConfig } from "./types.js";
 import { listModelsViaRunner } from "../client/sdk-child.js";
+import { discoverModelsFromCursorAgent } from "../cli/model-discovery.js";
+import { resolveSdkApiKey } from "../auth.js";
+import { parseCursorBackendPreference } from "../provider/backend.js";
 
 interface CacheEntry {
   models: ModelInfo[];
@@ -22,20 +25,42 @@ export class ModelDiscoveryService {
       return this.cache.models;
     }
 
-    try {
-      const models = await this.queryViaSdk(apiKey);
-      this.cache = { models, timestamp: Date.now() };
-      return models;
-    } catch (error) {
-      // Return fallback on error
-      return this.fallbackModels;
+    const backendPreference = parseCursorBackendPreference(process.env.CURSOR_ACP_BACKEND).preference;
+    const queryOrder = backendPreference === "sdk"
+      ? ["sdk"]
+      : backendPreference === "cursor-agent"
+        ? ["cursor-agent"]
+        : ["cursor-agent", "sdk"];
+
+    for (const backend of queryOrder) {
+      try {
+        const models = backend === "cursor-agent"
+          ? await this.queryCursorAgent()
+          : await this.queryViaSdk(apiKey);
+        this.cache = { models, timestamp: Date.now() };
+        return models;
+      } catch {
+        // Try the next backend before falling back to static defaults.
+      }
     }
+
+    this.cache = { models: this.fallbackModels, timestamp: Date.now() };
+    return this.fallbackModels;
+  }
+
+  async queryCursorAgent(apiKey?: string): Promise<ModelInfo[]> {
+    void apiKey;
+    return discoverModelsFromCursorAgent().map((model) => ({
+      id: model.id,
+      name: model.name,
+      description: `Cursor ${model.name} model`,
+    }));
   }
 
   private async queryViaSdk(apiKey?: string): Promise<ModelInfo[]> {
     // Use the SDK runner to list models
-    const key = apiKey ?? process.env.CURSOR_API_KEY;
-    if (!key || !key.trim()) {
+    const key = resolveSdkApiKey({ env: process.env, storedApiKey: apiKey });
+    if (!key) {
       throw new Error("No Cursor API key available");
     }
 

--- a/src/models/sync.ts
+++ b/src/models/sync.ts
@@ -12,6 +12,7 @@ import {
   writeFileSync as nodeWriteFileSync,
 } from "node:fs";
 import { listModelsViaRunner } from "../client/sdk-child.js";
+import { resolveSdkApiKey } from "../auth.js";
 import { resolveOpenCodeConfigPath } from "../plugin-toggle.js";
 import { createLogger, type Logger } from "../utils/logger.js";
 
@@ -42,8 +43,8 @@ type AutoRefreshModelsDeps = {
 const defaultDeps: AutoRefreshModelsDeps = {
   defer: () => Promise.resolve(),
   discoverModels: async () => {
-    const apiKey = process.env.CURSOR_API_KEY;
-    if (!apiKey || !apiKey.trim()) {
+    const apiKey = resolveSdkApiKey({ env: process.env });
+    if (!apiKey) {
       throw new Error("CURSOR_API_KEY not set");
     }
     const models = await listModelsViaRunner(apiKey);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin, PluginInput } from "@opencode-ai/plugin";
 import { tool } from "@opencode-ai/plugin";
 import type { Auth } from "@opencode-ai/sdk";
+import { spawn, spawnSync } from "child_process";
 import { realpathSync } from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
@@ -63,6 +64,13 @@ import {
   type ToolLoopGuard,
 } from "./provider/tool-loop-guard.js";
 import { createSdkBunChild, createSdkNodeChild } from "./client/sdk-child.js";
+import {
+  parseCursorBackendPreference,
+  resolveSdkApiKey,
+  selectBackendForRequest,
+  type CursorRuntimeBackend,
+} from "./provider/backend.js";
+import { formatShellCommandForPlatform, resolveCursorAgentBinary } from "./utils/binary.js";
 
 const log = createLogger("plugin");
 
@@ -166,9 +174,137 @@ const REUSE_EXISTING_PROXY = process.env.CURSOR_ACP_REUSE_EXISTING_PROXY !== "fa
 
 // Stored API key from auth loader (OpenCode auth store)
 let storedApiKey: string | undefined;
+let cursorAgentAvailabilityCache: boolean | undefined;
 
 function getGlobalKey(): string {
   return "__opencode_cursor_proxy_server__";
+}
+
+function isCursorAgentAvailable(): boolean {
+  if (cursorAgentAvailabilityCache !== undefined) {
+    return cursorAgentAvailabilityCache;
+  }
+
+  const binary = resolveCursorAgentBinary();
+  const result = spawnSync(formatShellCommandForPlatform(binary), ["--version"], {
+    stdio: "ignore",
+    timeout: 1000,
+    shell: process.platform === "win32",
+  });
+  const error = result.error as NodeJS.ErrnoException | undefined;
+
+  // ENOENT is the one signal that the binary is clearly absent. Other failures
+  // mean the command path exists but the probe could not complete cleanly.
+  cursorAgentAvailabilityCache = error?.code === "ENOENT" ? false : true;
+  return cursorAgentAvailabilityCache;
+}
+
+function resolveBackendForRequest(sdkApiKey: string | undefined): CursorRuntimeBackend {
+  const parsed = parseCursorBackendPreference(process.env.CURSOR_ACP_BACKEND);
+  if (!parsed.valid) {
+    log.warn("Invalid CURSOR_ACP_BACKEND value; falling back to auto", {
+      value: process.env.CURSOR_ACP_BACKEND,
+    });
+  }
+
+  return selectBackendForRequest({
+    preference: parsed.preference,
+    cursorAgentAvailable: isCursorAgentAvailable(),
+    sdkApiKey,
+  });
+}
+
+function buildCursorAgentCommand(model: string, workspaceDirectory: string): string[] {
+  const cmd = [
+    resolveCursorAgentBinary(),
+    "--print",
+    "--output-format",
+    "stream-json",
+    "--stream-partial-output",
+    "--workspace",
+    workspaceDirectory,
+    "--model",
+    model,
+  ];
+  if (FORCE_TOOL_MODE) {
+    cmd.push("--force");
+  }
+  return cmd;
+}
+
+function createCursorAgentBunChild(model: string, prompt: string, workspaceDirectory: string): any {
+  const bunAny = globalThis as any;
+  if (!bunAny.Bun?.spawn) {
+    throw new Error("This provider requires Bun runtime.");
+  }
+
+  const child = bunAny.Bun.spawn({
+    cmd: buildCursorAgentCommand(model, workspaceDirectory),
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunAny.Bun.env,
+  });
+
+  child.stdin.write(prompt);
+  child.stdin.end();
+  return child;
+}
+
+function createBunChildForBackend(input: {
+  backend: CursorRuntimeBackend;
+  sdkApiKey?: string;
+  model: string;
+  prompt: string;
+  workspaceDirectory: string;
+}): any {
+  if (input.backend === "sdk") {
+    if (!input.sdkApiKey) {
+      throw new Error("SDK backend requires CURSOR_API_KEY or OpenCode auth.");
+    }
+    return createSdkBunChild({
+      apiKey: input.sdkApiKey,
+      model: input.model,
+      prompt: input.prompt,
+      cwd: input.workspaceDirectory,
+    });
+  }
+
+  return createCursorAgentBunChild(input.model, input.prompt, input.workspaceDirectory);
+}
+
+function createCursorAgentNodeChild(model: string, prompt: string, workspaceDirectory: string): any {
+  const cmd = buildCursorAgentCommand(model, workspaceDirectory);
+  const child = spawn(formatShellCommandForPlatform(cmd[0]), cmd.slice(1), {
+    stdio: ["pipe", "pipe", "pipe"],
+    shell: process.platform === "win32",
+  });
+
+  child.stdin.write(prompt);
+  child.stdin.end();
+  return child;
+}
+
+function createNodeChildForBackend(input: {
+  backend: CursorRuntimeBackend;
+  sdkApiKey?: string;
+  model: string;
+  prompt: string;
+  workspaceDirectory: string;
+}): any {
+  if (input.backend === "sdk") {
+    if (!input.sdkApiKey) {
+      throw new Error("SDK backend requires CURSOR_API_KEY or OpenCode auth.");
+    }
+    return createSdkNodeChild({
+      apiKey: input.sdkApiKey,
+      model: input.model,
+      prompt: input.prompt,
+      cwd: input.workspaceDirectory,
+    });
+  }
+
+  return createCursorAgentNodeChild(input.model, input.prompt, input.workspaceDirectory);
 }
 
 function getOpenCodeConfigPrefix(): string {
@@ -636,38 +772,12 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
   // Mark as starting to avoid duplicate starts in-process.
   state.baseURL = "";
 
-  /**
-   * Resolve API key from multiple sources with priority:
-   * 1. process.env.CURSOR_API_KEY (highest priority)
-   * 2. storedApiKey (from OpenCode auth loader)
-   * 3. Authorization header from request (format: "Bearer <key>" or just "<key>")
-   */
-  const resolveApiKey = (authHeader?: string | null): string | undefined => {
-    // Priority 1: environment variable
-    const envKey = process.env.CURSOR_API_KEY;
-    if (envKey && envKey.trim()) {
-      return envKey;
-    }
-
-    // Priority 2: stored key from auth loader
-    if (storedApiKey && storedApiKey.trim()) {
-      return storedApiKey;
-    }
-
-    // Priority 3: Authorization header
-    if (authHeader && authHeader.trim()) {
-      const trimmed = authHeader.trim();
-      // Handle "Bearer <key>" format
-      if (trimmed.toLowerCase().startsWith("bearer ")) {
-        const key = trimmed.slice(7).trim();
-        return key || undefined;
-      }
-      // Handle raw key format
-      return trimmed || undefined;
-    }
-
-    return undefined;
-  };
+  const resolveRequestSdkApiKey = (authHeader?: string | null): string | undefined =>
+    resolveSdkApiKey({
+      env: process.env,
+      storedApiKey,
+      authorizationHeader: authHeader,
+    });
 
       const handler = async (req: Request): Promise<Response> => {
         try {
@@ -685,7 +795,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
         try {
           const { ModelDiscoveryService } = await import("./models/discovery.js");
           const discovery = new ModelDiscoveryService();
-          const modelList = await discovery.discover(resolveApiKey());
+          const modelList = await discovery.discover(resolveRequestSdkApiKey());
           const models = modelList.map((m: any) => ({
             id: typeof m === "string" ? m : m.id,
             object: "model",
@@ -756,15 +866,22 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
       });
 
       const authHeader = req.headers.get("authorization");
-      const apiKey = resolveApiKey(authHeader);
-      if (!apiKey || !apiKey.trim()) {
+      const sdkApiKey = resolveRequestSdkApiKey(authHeader);
+      const backend = resolveBackendForRequest(sdkApiKey);
+      if (backend === "sdk" && !sdkApiKey) {
         return new Response(
-          JSON.stringify({ error: "Cursor API key not found. Set CURSOR_API_KEY, run `opencode auth login`, or set provider options.apiKey in opencode.json." }),
+          JSON.stringify({ error: "Cursor SDK backend requires a real Cursor API key. Set CURSOR_API_KEY or run `opencode auth login`; the legacy `cursor-agent` placeholder is not valid SDK auth." }),
           { status: 401, headers: { "Content-Type": "application/json" } },
         );
       }
 
-      const child = createSdkBunChild({ apiKey, model, prompt, cwd: workspaceDirectory });
+      const child = createBunChildForBackend({
+        backend,
+        sdkApiKey,
+        model,
+        prompt,
+        workspaceDirectory,
+      });
 
       if (!stream) {
         const [stdoutText, stderrText] = await Promise.all([
@@ -1144,7 +1261,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
         try {
           const { ModelDiscoveryService } = await import("./models/discovery.js");
           const discovery = new ModelDiscoveryService();
-          const modelList = await discovery.discover(resolveApiKey());
+          const modelList = await discovery.discover(resolveRequestSdkApiKey());
           const models = modelList.map((m: any) => ({
             id: typeof m === "string" ? m : m.id,
             object: "model",
@@ -1205,14 +1322,21 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
       });
 
       const authHeaderNode = req.headers["authorization"] as string | undefined;
-      const apiKeyNode = resolveApiKey(authHeaderNode);
-      if (!apiKeyNode || !apiKeyNode.trim()) {
+      const sdkApiKeyNode = resolveRequestSdkApiKey(authHeaderNode);
+      const backend = resolveBackendForRequest(sdkApiKeyNode);
+      if (backend === "sdk" && !sdkApiKeyNode) {
         res.writeHead(401, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Cursor API key not found. Set CURSOR_API_KEY, run `opencode auth login`, or set provider options.apiKey in opencode.json." }));
+        res.end(JSON.stringify({ error: "Cursor SDK backend requires a real Cursor API key. Set CURSOR_API_KEY or run `opencode auth login`; the legacy `cursor-agent` placeholder is not valid SDK auth." }));
         return;
       }
 
-      const child = createSdkNodeChild({ apiKey: apiKeyNode, model, prompt, cwd: workspaceDirectory });
+      const child = createNodeChildForBackend({
+        backend,
+        sdkApiKey: sdkApiKeyNode,
+        model,
+        prompt,
+        workspaceDirectory,
+      });
 
       if (!stream) {
         const stdoutChunks: Buffer[] = [];

--- a/src/provider/backend.ts
+++ b/src/provider/backend.ts
@@ -1,0 +1,71 @@
+export {
+  isUsableSdkApiKey,
+  normalizeAuthorizationHeader,
+  resolveSdkApiKey,
+  type ResolveSdkApiKeyInput,
+} from "../auth.js";
+import { isUsableSdkApiKey } from "../auth.js";
+
+export type CursorBackendPreference = "auto" | "cursor-agent" | "sdk";
+export type CursorRuntimeBackend = "cursor-agent" | "sdk";
+
+export interface BackendPreferenceParseResult {
+  preference: CursorBackendPreference;
+  valid: boolean;
+}
+
+export interface SelectBackendForRequestInput {
+  preference: CursorBackendPreference;
+  cursorAgentAvailable: boolean;
+  sdkApiKey?: string;
+}
+
+export function parseCursorBackendPreference(
+  value: string | undefined,
+): BackendPreferenceParseResult {
+  if (value === undefined || value.trim() === "") {
+    return { preference: "auto", valid: true };
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (
+    normalized === "auto" ||
+    normalized === "cursor-agent" ||
+    normalized === "sdk"
+  ) {
+    return { preference: normalized, valid: true };
+  }
+
+  return { preference: "auto", valid: false };
+}
+
+export function selectInitialBackend(
+  preference: CursorBackendPreference,
+): CursorRuntimeBackend {
+  return preference === "sdk" ? "sdk" : "cursor-agent";
+}
+
+export function shouldFallbackToSdk(
+  preference: CursorBackendPreference,
+  sdkApiKey: string | undefined,
+): boolean {
+  return preference === "auto" && isUsableSdkApiKey(sdkApiKey);
+}
+
+export function selectBackendForRequest(
+  input: SelectBackendForRequestInput,
+): CursorRuntimeBackend {
+  if (input.preference === "sdk") {
+    return "sdk";
+  }
+
+  if (
+    input.preference === "auto" &&
+    !input.cursorAgentAvailable &&
+    isUsableSdkApiKey(input.sdkApiKey)
+  ) {
+    return "sdk";
+  }
+
+  return "cursor-agent";
+}

--- a/tests/unit/cli/opencode-cursor.test.ts
+++ b/tests/unit/cli/opencode-cursor.test.ts
@@ -81,6 +81,42 @@ describe("cli/opencode-cursor commandDoctor", () => {
     expect(results.length).toBeGreaterThan(5);
     expect(results.every(r => typeof r.passed === "boolean")).toBe(true);
   }, 10000);
+
+  it("reports missing cursor-agent as a warning when SDK backend has a real key", () => {
+    const originalBackend = process.env.CURSOR_ACP_BACKEND;
+    const originalApiKey = process.env.CURSOR_API_KEY;
+    const originalCursorAgent = process.env.CURSOR_AGENT_EXECUTABLE;
+
+    process.env.CURSOR_ACP_BACKEND = "sdk";
+    process.env.CURSOR_API_KEY = "cursor_123";
+    process.env.CURSOR_AGENT_EXECUTABLE = "/definitely/missing/cursor-agent";
+
+    try {
+      const results = runDoctorChecks("/tmp/test-config.json", "/tmp/test-plugin");
+      const cursorAgent = results.find((result) => result.name === "cursor-agent");
+      const sdkAuth = results.find((result) => result.name === "Cursor SDK API key");
+
+      expect(cursorAgent?.passed).toBe(false);
+      expect(cursorAgent?.warning).toBe(true);
+      expect(sdkAuth?.passed).toBe(true);
+    } finally {
+      if (originalBackend === undefined) {
+        delete process.env.CURSOR_ACP_BACKEND;
+      } else {
+        process.env.CURSOR_ACP_BACKEND = originalBackend;
+      }
+      if (originalApiKey === undefined) {
+        delete process.env.CURSOR_API_KEY;
+      } else {
+        process.env.CURSOR_API_KEY = originalApiKey;
+      }
+      if (originalCursorAgent === undefined) {
+        delete process.env.CURSOR_AGENT_EXECUTABLE;
+      } else {
+        process.env.CURSOR_AGENT_EXECUTABLE = originalCursorAgent;
+      }
+    }
+  });
 });
 
 describe("cli/opencode-cursor status", () => {

--- a/tests/unit/mcp/tool-bridge.test.ts
+++ b/tests/unit/mcp/tool-bridge.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "bun:test";
-import { buildMcpToolHookEntries } from "../../../src/mcp/tool-bridge.js";
+import {
+  buildMcpToolDefinitions,
+  buildMcpToolHookEntries,
+  namespaceMcpTool,
+} from "../../../src/mcp/tool-bridge.js";
 
 describe("mcp/tool-bridge", () => {
   it("creates tool hook entries for discovered MCP tools", () => {
@@ -39,6 +43,22 @@ describe("mcp/tool-bridge", () => {
       "mcp__my_server__search",
       "mcp__my_server__store",
     ]);
+  });
+
+  it("uses one sanitized MCP namespace for hyphenated server and tool names", () => {
+    const tools = [
+      { name: "memory-search", serverName: "hybrid-memory", description: "Search memory" },
+    ];
+
+    expect(namespaceMcpTool("hybrid-memory", "memory-search")).toBe(
+      "mcp__hybrid_memory__memory_search",
+    );
+
+    const entries = buildMcpToolHookEntries(tools as any, { callTool: async () => "" } as any);
+    expect(Object.keys(entries)).toEqual(["mcp__hybrid_memory__memory_search"]);
+
+    const defs = buildMcpToolDefinitions(tools as any);
+    expect(defs[0]?.function?.name).toBe("mcp__hybrid_memory__memory_search");
   });
 
   it("handles tools with no inputSchema", () => {

--- a/tests/unit/models/discovery.test.ts
+++ b/tests/unit/models/discovery.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { ModelDiscoveryService } from "../../../src/models/discovery.js";
+
+describe("models/discovery", () => {
+  it("does not pass the legacy cursor-agent placeholder to SDK model discovery", async () => {
+    const originalApiKey = process.env.CURSOR_API_KEY;
+    const originalRunnerPath = process.env.CURSOR_ACP_SDK_RUNNER_PATH;
+    process.env.CURSOR_API_KEY = "cursor-agent";
+    process.env.CURSOR_ACP_SDK_RUNNER_PATH = "/definitely/missing/sdk-runner.mjs";
+
+    const service = new ModelDiscoveryService();
+
+    try {
+      await expect((service as any).queryViaSdk()).rejects.toThrow("No Cursor API key available");
+    } finally {
+      if (originalApiKey === undefined) {
+        delete process.env.CURSOR_API_KEY;
+      } else {
+        process.env.CURSOR_API_KEY = originalApiKey;
+      }
+      if (originalRunnerPath === undefined) {
+        delete process.env.CURSOR_ACP_SDK_RUNNER_PATH;
+      } else {
+        process.env.CURSOR_ACP_SDK_RUNNER_PATH = originalRunnerPath;
+      }
+    }
+  });
+});

--- a/tests/unit/provider-backend.test.ts
+++ b/tests/unit/provider-backend.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isUsableSdkApiKey,
+  parseCursorBackendPreference,
+  resolveSdkApiKey,
+  selectBackendForRequest,
+  selectInitialBackend,
+  shouldFallbackToSdk,
+} from "../../src/provider/backend";
+
+describe("provider backend compatibility", () => {
+  it("defaults to auto and accepts explicit backend preferences", () => {
+    expect(parseCursorBackendPreference(undefined)).toEqual({ preference: "auto", valid: true });
+    expect(parseCursorBackendPreference("auto")).toEqual({ preference: "auto", valid: true });
+    expect(parseCursorBackendPreference("cursor-agent")).toEqual({ preference: "cursor-agent", valid: true });
+    expect(parseCursorBackendPreference("sdk")).toEqual({ preference: "sdk", valid: true });
+    expect(parseCursorBackendPreference("nonsense")).toEqual({ preference: "auto", valid: false });
+  });
+
+  it("does not treat the historical cursor-agent placeholder as a real SDK API key", () => {
+    expect(isUsableSdkApiKey(undefined)).toBe(false);
+    expect(isUsableSdkApiKey("")).toBe(false);
+    expect(isUsableSdkApiKey("cursor-agent")).toBe(false);
+    expect(isUsableSdkApiKey("  cursor-agent  ")).toBe(false);
+    expect(isUsableSdkApiKey("cursor_123")).toBe(true);
+    expect(isUsableSdkApiKey("sk-real-key")).toBe(true);
+  });
+
+  it("resolves SDK keys from env, stored auth, then Authorization header", () => {
+    expect(
+      resolveSdkApiKey({
+        env: { CURSOR_API_KEY: "env-key" },
+        storedApiKey: "stored-key",
+        authorizationHeader: "Bearer header-key",
+      }),
+    ).toBe("env-key");
+
+    expect(
+      resolveSdkApiKey({
+        env: {},
+        storedApiKey: "stored-key",
+        authorizationHeader: "Bearer header-key",
+      }),
+    ).toBe("stored-key");
+
+    expect(
+      resolveSdkApiKey({
+        env: {},
+        authorizationHeader: "Bearer header-key",
+      }),
+    ).toBe("header-key");
+  });
+
+  it("ignores placeholder Authorization header values so auto can preserve cursor-agent", () => {
+    expect(
+      resolveSdkApiKey({
+        env: {},
+        authorizationHeader: "Bearer cursor-agent",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveSdkApiKey({
+        env: {},
+        authorizationHeader: "cursor-agent",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("prefers cursor-agent in auto mode and only falls back to SDK when a real key exists", () => {
+    expect(selectInitialBackend("auto")).toBe("cursor-agent");
+    expect(selectInitialBackend("cursor-agent")).toBe("cursor-agent");
+    expect(selectInitialBackend("sdk")).toBe("sdk");
+
+    expect(shouldFallbackToSdk("auto", "cursor_123")).toBe(true);
+    expect(shouldFallbackToSdk("auto", "cursor-agent")).toBe(false);
+    expect(shouldFallbackToSdk("cursor-agent", "cursor_123")).toBe(false);
+    expect(shouldFallbackToSdk("sdk", "cursor_123")).toBe(false);
+  });
+
+  it("uses SDK in auto mode only when cursor-agent is unavailable and SDK auth is real", () => {
+    expect(
+      selectBackendForRequest({
+        preference: "auto",
+        cursorAgentAvailable: true,
+        sdkApiKey: "cursor_123",
+      }),
+    ).toBe("cursor-agent");
+
+    expect(
+      selectBackendForRequest({
+        preference: "auto",
+        cursorAgentAvailable: false,
+        sdkApiKey: "cursor_123",
+      }),
+    ).toBe("sdk");
+
+    expect(
+      selectBackendForRequest({
+        preference: "auto",
+        cursorAgentAvailable: false,
+        sdkApiKey: "cursor-agent",
+      }),
+    ).toBe("cursor-agent");
+
+    expect(
+      selectBackendForRequest({
+        preference: "sdk",
+        cursorAgentAvailable: true,
+        sdkApiKey: "cursor_123",
+      }),
+    ).toBe("sdk");
+  });
+});

--- a/tests/unit/sdk-child.test.ts
+++ b/tests/unit/sdk-child.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createSdkNodeChild,
+  listModelsViaRunner,
+  resolveRunnerPath,
+  stopSdkRunner,
+} from "../../src/client/sdk-child.js";
+
+const FAKE_RUNNER = `#!/usr/bin/env node
+process.stdin.setEncoding("utf8");
+let buffer = "";
+
+function emit(payload) {
+  process.stdout.write(JSON.stringify(payload) + "\\n");
+}
+
+function handle(line) {
+  const request = JSON.parse(line);
+  if (request.op === "listModels") {
+    emit({
+      id: request.id,
+      event: {
+        type: "models",
+        models: [{ id: "fake-model", name: "Fake Model" }],
+      },
+    });
+    emit({ id: request.id, done: true, exitCode: 0 });
+    return;
+  }
+
+  emit({
+    id: request.id,
+    event: {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "fake sdk response" }],
+      },
+    },
+  });
+  emit({ id: request.id, done: true, exitCode: 0 });
+}
+
+process.stdin.on("data", (chunk) => {
+  buffer += chunk;
+  const lines = buffer.split("\\n");
+  buffer = lines.pop() || "";
+  for (const line of lines) {
+    if (line.trim()) handle(line);
+  }
+});
+`;
+
+async function streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+function waitForClose(child: NodeJS.EventEmitter): Promise<number> {
+  return new Promise((resolve, reject) => {
+    child.once("close", resolve);
+    child.once("error", reject);
+  });
+}
+
+describe("sdk-child runner path resolution", () => {
+  it("resolves sdk-runner.mjs from source module layout", () => {
+    const result = resolveRunnerPath("/pkg/src/client/sdk-child.ts", (candidate) =>
+      candidate === "/pkg/scripts/sdk-runner.mjs",
+    );
+
+    expect(result).toBe("/pkg/scripts/sdk-runner.mjs");
+  });
+
+  it("resolves sdk-runner.mjs from bundled dist/plugin-entry.js layout", () => {
+    const result = resolveRunnerPath("/pkg/dist/plugin-entry.js", (candidate) =>
+      candidate === "/pkg/scripts/sdk-runner.mjs",
+    );
+
+    expect(result).toBe("/pkg/scripts/sdk-runner.mjs");
+  });
+
+  it("uses an explicit fake runner path for SDK chat and model-list smoke", async () => {
+    const originalRunnerPath = process.env.CURSOR_ACP_SDK_RUNNER_PATH;
+    const dir = mkdtempSync(join(tmpdir(), "open-cursor-fake-runner-"));
+    const runnerPath = join(dir, "fake-runner.mjs");
+    writeFileSync(runnerPath, FAKE_RUNNER, "utf8");
+    chmodSync(runnerPath, 0o755);
+
+    process.env.CURSOR_ACP_SDK_RUNNER_PATH = runnerPath;
+
+    try {
+      const child = createSdkNodeChild({
+        apiKey: "cursor_123",
+        model: "auto",
+        prompt: "hello",
+        cwd: dir,
+      });
+
+      const [stdout, exitCode] = await Promise.all([
+        streamToString(child.stdout),
+        waitForClose(child),
+      ]);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("fake sdk response");
+
+      const models = await listModelsViaRunner("cursor_123");
+      expect(models).toEqual([{ id: "fake-model", name: "Fake Model" }]);
+    } finally {
+      stopSdkRunner();
+      if (originalRunnerPath === undefined) {
+        delete process.env.CURSOR_ACP_SDK_RUNNER_PATH;
+      } else {
+        process.env.CURSOR_ACP_SDK_RUNNER_PATH = originalRunnerPath;
+      }
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/sdk-runner.test.ts
+++ b/tests/unit/sdk-runner.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { sdkMessageToStreamJson } from "../../scripts/sdk-runner.mjs";
+
+describe("sdk-runner MCP remapping", () => {
+  it("sanitizes generic SDK mcp tool calls with the same namespace convention as OpenCode MCP tools", () => {
+    const event = sdkMessageToStreamJson({
+      type: "tool_call",
+      call_id: "call-1",
+      name: "mcp",
+      args: {
+        providerIdentifier: "hybrid-memory",
+        toolName: "memory-search",
+        args: { query: "release notes" },
+      },
+    });
+
+    expect(event).toEqual({
+      type: "tool_call",
+      call_id: "call-1",
+      tool_call: {
+        mcp__hybrid_memory__memory_search: {
+          args: { query: "release notes" },
+          result: undefined,
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Keep existing binary-backed workflows working in automatic mode, while using the SDK path only when explicitly selected or as a real-key fallback.
- Split legacy auth from SDK API-key auth, preserve OpenCode-owned MCP execution, and fix packaged runner path resolution.
- Make the SDK dependency optional, restore source install symlink behavior, and keep model discovery on the legacy path when available.

## Test plan
- `npm ci --omit=optional && npm ci`
- `npm run build`
- `npm run test:ci:unit` (323 pass)
- `npm run test:ci:integration` (30 pass, 1 existing skip)
- SDK runner no-key smoke: expected `CURSOR_API_KEY not set`
- `npm pack --dry-run --json` includes `dist/plugin-entry.js` and `scripts/sdk-runner.mjs`

Note: a live SDK request was not run because no real `CURSOR_API_KEY` was available locally.

Made with [Cursor](https://cursor.com)