### PR TITLE
feat(models): add Claude Fable 5 and Claude Opus 4.8 pricing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Add to `~/.config/opencode/opencode.json` (or `%USERPROFILE%\.config\opencode\op
       "models": {
         "cursor-acp/auto":              { "name": "Auto" },
 
+        "cursor-acp/claude-opus-4-8":   { "name": "Claude Opus 4.8" },
         "cursor-acp/claude-opus-4-7":   { "name": "Claude 4.7 Opus" },
         "cursor-acp/claude-4.6-opus":   { "name": "Claude 4.6 Opus" },
         "cursor-acp/claude-4.6-sonnet": { "name": "Claude 4.6 Sonnet" },
@@ -83,6 +84,8 @@ Add to `~/.config/opencode/opencode.json` (or `%USERPROFILE%\.config\opencode\op
         "cursor-acp/composer-2":        { "name": "Composer 2" },
         "cursor-acp/composer-2-fast":   { "name": "Composer 2 Fast" },
         "cursor-acp/composer-1.5":      { "name": "Composer 1.5" },
+
+        "cursor-acp/claude-fable-5":    { "name": "Claude Fable 5" },
 
         "cursor-acp/grok-4-20":         { "name": "Grok 4.20" },
         "cursor-acp/kimi-k2.5":         { "name": "Kimi K2.5" }

--- a/src/models/pricing.ts
+++ b/src/models/pricing.ts
@@ -25,6 +25,8 @@ export const CURSOR_PRICING_DOC_MARKERS = [
   "Claude 4.6",
   "Claude 4.6 Sonnet",
   "Claude Opus 4.7",
+  "Claude Opus 4.8",
+  "Claude Fable 5",
   "Gemini 3.1 Pro",
   "Gemini 3 Flash",
   "GPT-5.3 Codex",
@@ -49,6 +51,10 @@ const CLAUDE_SONNET_WITH_LONG_CONTEXT_COST = withLongContext(
 const CLAUDE_OPUS_COST = cost(5, 25, 0.5, 6.25);
 const CLAUDE_OPUS_FAST_COST = cost(30, 150, 3, 37.5);
 
+// Claude Fable 5: Anthropic Mythos-class frontier model (high cost tier per cursor.com/docs/models/claude-fable-5).
+// Priced at the Opus rate until Cursor publishes official per-token pricing.
+const CLAUDE_FABLE_5_COST = CLAUDE_OPUS_COST;
+
 const GEMINI_3_PRO_COST = withLongContext(cost(2, 12, 0.2, 2), cost(4, 18, 0.4, 4));
 const GEMINI_3_FLASH_COST = cost(0.5, 3, 0.05, 0.5);
 
@@ -71,6 +77,7 @@ export function getCursorModelCost(modelId: string): OpenCodeModelCost | undefin
   if (modelId === "composer-2") return COMPOSER_2_COST;
   if (modelId === "composer-1.5") return COMPOSER_1_5_COST;
 
+  if (modelId.startsWith("claude-opus-4-8")) return CLAUDE_OPUS_COST;
   if (modelId.startsWith("claude-opus-4-7")) return CLAUDE_OPUS_COST;
   if (modelId.startsWith("claude-4.6-opus")) {
     return modelId.endsWith("-fast") ? CLAUDE_OPUS_FAST_COST : CLAUDE_OPUS_COST;
@@ -99,6 +106,7 @@ export function getCursorModelCost(modelId: string): OpenCodeModelCost | undefin
 
   if (modelId.startsWith("grok-4-20")) return GROK_4_20_COST;
   if (modelId === "kimi-k2.5") return KIMI_K2_5_COST;
+  if (modelId.startsWith("claude-fable-5")) return CLAUDE_FABLE_5_COST;
 
   return undefined;
 }


### PR DESCRIPTION
## Summary

Adds pricing support for two new Anthropic models that are available through Cursor but not yet tracked in the package:

- **Claude Fable 5** () — Anthropic's Mythos-class model for autonomous, long-running agentic work ([Cursor docs](https://cursor.com/docs/models/claude-fable-5))
- **Claude Opus 4.8** () — Latest generation of Anthropic's Opus family

## Changes

### `src/models/pricing.ts`
- Added `CLAUDE_FABLE_5_COST` constant, mapped to the Opus cost tier (high) as documented on the Cursor model page. Includes an inline comment noting that the rate should be updated once Cursor publishes official per-token pricing on their pricing page.
- Added `claude-opus-4-8` handler in `getCursorModelCost`, using the established Opus cost tier (same as `claude-opus-4-7`).
- Updated `CURSOR_PRICING_DOC_MARKERS` to include both new models for pricing coverage tracking.

### `README.md`
- Added both models to the Option C static config example, positioned consistently with the rest of the Claude family.

## Verification

Model IDs confirmed from official Cursor documentation:
- `claude-fable-5`: https://cursor.com/docs/models/claude-fable-5
- `claude-opus-4-8`: follows the established `claude-opus-4-{version}` naming convention

Pricing for Claude Fable 5 is a best-effort estimate (Opus tier) with a source comment. Once Cursor updates https://cursor.com/docs/models-and-pricing with official per-token rates, `CLAUDE_FABLE_5_COST` should be updated to match.

## Notes

- No breaking changes — purely additive to the pricing lookup and README example
- The `sync-models` CLI will continue to auto-discover these models from the live Cursor API regardless of this static list; this PR ensures cost estimation works correctly in the meantime