### PR TITLE
fix: avoid broken opencode plugin root import

### DIFF
--- a/src/mcp/tool-bridge.ts
+++ b/src/mcp/tool-bridge.ts
@@ -1,4 +1,4 @@
-import { tool } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin/tool";
 import { createLogger } from "../utils/logger.js";
 import type { McpClientManager } from "./client-manager.js";
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,5 +1,5 @@
 import type { Plugin, PluginInput } from "@opencode-ai/plugin";
-import { tool } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin/tool";
 import type { Auth } from "@opencode-ai/sdk";
 import { spawn, spawnSync } from "child_process";
 import { realpathSync } from "fs";

--- a/tests/unit/plugin.test.ts
+++ b/tests/unit/plugin.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "child_process";
 import { existsSync, rmSync, mkdirSync, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -57,5 +58,34 @@ describe("Plugin Directory Initialization", () => {
     await ensurePluginDirectory();
     
     expect(existsSync(testPluginDir)).toBe(true);
+  });
+});
+
+describe("Plugin entry module", () => {
+  it("imports the built plugin entry under Node ESM", () => {
+    expect(existsSync("dist/plugin-entry.js")).toBe(true);
+
+    const result = spawnSync(
+      "node",
+      [
+        "-e",
+        "import('./dist/plugin-entry.js').then(()=>console.log('import ok')).catch(e=>{console.error(e.stack||e.message); process.exit(1)})",
+      ],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+      },
+    );
+
+    if (result.status !== 0) {
+      throw new Error(
+        [
+          "Node failed to import dist/plugin-entry.js",
+          `stdout: ${result.stdout.trim()}`,
+          `stderr: ${result.stderr.trim()}`,
+        ].join("\n"),
+      );
+    }
+    expect(result.status).toBe(0);
   });
 });


### PR DESCRIPTION
Refs #82

This switches the runtime tool helper imports from the root @opencode-ai/plugin entrypoint to the package's exported @opencode-ai/plugin/tool subpath. The root entrypoint in 1.1.53 emits an extensionless ESM import, which breaks Node/Electron when loading the built plugin.

Also adds a regression test that imports dist/plugin-entry.js with Node after build, which catches the reported failure path directly.

Verification:
- npm run build
- npm test -- tests/unit/plugin.test.ts tests/unit/mcp/tool-bridge.test.ts
- node -e "import('./dist/plugin-entry.js').then(()=>console.log('import ok')).catch(e=>{console.error(e.stack||e.message); process.exit(1)})"

Note: I also tried npm run test:ci:unit locally, but this machine hit proxy port bind exhaustion in unrelated proxy startup tests before the suite could complete.