### PR TITLE
feat: add model refresh controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ The proxy uses a dual-backend runtime. In `auto` mode (default) it prefers the `
 By default, the SDK Agent runs in isolated mode (`settingSources: []`). To load Cursor environment settings in SDK mode, set `CURSOR_ACP_SETTING_SOURCES=all`.
 
 Default tool-loop mode: `CURSOR_ACP_TOOL_LOOP_MODE=opencode`. Details: [docs/architecture/runtime-tool-loop.md](docs/architecture/runtime-tool-loop.md).
+
+Startup model refresh is additive by default. Use `CURSOR_ACP_MODEL_AUTO_REFRESH=false` to disable it, or `CURSOR_ACP_MODEL_AUTO_REFRESH=compact` to fold Cursor model variants into opencode variants.
 </details>
 
 ## Alternatives

--- a/src/models/sync.ts
+++ b/src/models/sync.ts
@@ -15,10 +15,12 @@ import { listModelsViaRunner } from "../client/sdk-child.js";
 import { resolveSdkApiKey } from "../auth.js";
 import { resolveOpenCodeConfigPath } from "../plugin-toggle.js";
 import { createLogger, type Logger } from "../utils/logger.js";
+import { mergeCursorModelEntries } from "./variants.js";
 
 const log = createLogger("model-sync");
 const PROVIDER_ID = "cursor-acp";
 
+type AutoRefreshMode = "disabled" | "direct" | "compact";
 type ModelConfigEntry = { name: string };
 type ProviderConfig = { models?: Record<string, unknown> } & Record<string, unknown>;
 type OpenCodeConfig = {
@@ -83,8 +85,41 @@ function getExistingModels(provider: ProviderConfig): Record<string, unknown> {
   return isRecord(provider.models) ? { ...provider.models } : {};
 }
 
+function readCursorModel(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const cursorModel = value.cursorModel;
+  return typeof cursorModel === "string" && cursorModel.trim().length > 0
+    ? cursorModel.trim()
+    : undefined;
+}
+
+function collectRepresentedModelIds(models: Record<string, unknown>): Set<string> {
+  const represented = new Set<string>(Object.keys(models));
+
+  for (const entry of Object.values(models)) {
+    if (!isRecord(entry)) continue;
+    const optionModel = readCursorModel(entry.options);
+    if (optionModel) represented.add(optionModel);
+
+    if (!isRecord(entry.variants)) continue;
+    for (const variantEntry of Object.values(entry.variants)) {
+      const variantModel = readCursorModel(variantEntry);
+      if (variantModel) represented.add(variantModel);
+    }
+  }
+
+  return represented;
+}
+
 function yieldForFireAndForget(): Promise<void> {
   return Promise.resolve();
+}
+
+function getAutoRefreshMode(env: NodeJS.ProcessEnv): AutoRefreshMode {
+  const raw = env.CURSOR_ACP_MODEL_AUTO_REFRESH?.trim().toLowerCase();
+  if (raw === "false") return "disabled";
+  if (raw === "compact") return "compact";
+  return "direct";
 }
 
 /**
@@ -92,8 +127,8 @@ function yieldForFireAndForget(): Promise<void> {
  *
  * - Reads the current opencode.json config
  * - Queries the SDK runner for available models
- * - Merges discovered models into the provider config (additive only)
- * - Writes back if any new models were added
+ * - Merges discovered models into the provider config
+ * - Writes back if new models were added or compacted
  *
  * This function never throws. All failures are logged at debug level
  * and silently ignored so plugin startup is never blocked.
@@ -110,6 +145,12 @@ export async function autoRefreshModels(
   await resolvedDeps.defer();
 
   try {
+    const refreshMode = getAutoRefreshMode(resolvedDeps.env);
+    if (refreshMode === "disabled") {
+      resolvedDeps.log.debug("Model auto-refresh disabled by CURSOR_ACP_MODEL_AUTO_REFRESH");
+      return;
+    }
+
     const configPath = resolveOpenCodeConfigPath(resolvedDeps.env);
     if (!resolvedDeps.existsSync(configPath)) {
       resolvedDeps.log.debug("Config file not found, skipping model auto-refresh", { configPath });
@@ -136,6 +177,34 @@ export async function autoRefreshModels(
     } catch (err) {
       resolvedDeps.log.debug("Model discovery failed, skipping auto-refresh", {
         error: String(err),
+      });
+      return;
+    }
+
+    if (refreshMode === "compact") {
+      const representedModelIds = collectRepresentedModelIds(existingModels);
+      const missingModels = discovered.filter(model => !representedModelIds.has(model.id));
+      const result = mergeCursorModelEntries(existingModels, discovered, {
+        variants: true,
+        compact: true,
+      });
+
+      if (missingModels.length === 0 && result.removedCount === 0) {
+        resolvedDeps.log.debug("Model auto-refresh: no new models found", {
+          existing: Object.keys(existingModels).length,
+          discovered: discovered.length,
+        });
+        return;
+      }
+
+      provider.models = result.models;
+      resolvedDeps.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf8");
+      resolvedDeps.log.info("Model auto-refresh: synced models", {
+        mode: refreshMode,
+        synced: result.syncedCount,
+        grouped: result.groupedCount,
+        removed: result.removedCount,
+        total: Object.keys(result.models).length,
       });
       return;
     }

--- a/src/models/sync.ts
+++ b/src/models/sync.ts
@@ -189,7 +189,11 @@ export async function autoRefreshModels(
         compact: true,
       });
 
-      if (missingModels.length === 0 && result.removedCount === 0) {
+      if (
+        missingModels.length === 0
+        && result.removedCount === 0
+        && modelsEqual(existingModels, result.models)
+      ) {
         resolvedDeps.log.debug("Model auto-refresh: no new models found", {
           existing: Object.keys(existingModels).length,
           discovered: discovered.length,
@@ -233,4 +237,11 @@ export async function autoRefreshModels(
   } catch (err) {
     resolvedDeps.log.debug("Model auto-refresh failed", { error: String(err) });
   }
+}
+
+function modelsEqual(
+  left: Record<string, unknown>,
+  right: Record<string, unknown>,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
 }

--- a/tests/unit/models/sync.test.ts
+++ b/tests/unit/models/sync.test.ts
@@ -77,6 +77,109 @@ describe("models/sync", () => {
     });
   });
 
+  it("uses direct additive sync when explicitly requested", async () => {
+    const { deps, writeFileSync } = createDeps({
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG: "/tmp/opencode.json",
+        CURSOR_ACP_MODEL_AUTO_REFRESH: "direct",
+      },
+      readFileSync: vi.fn(() =>
+        JSON.stringify({
+          provider: {
+            "cursor-acp": {
+              models: {
+                auto: { name: "Auto" },
+                "custom-model": { name: "Custom" },
+              },
+            },
+          },
+        }),
+      ),
+      discoverModels: vi.fn(async () => [
+        { id: "auto", name: "Auto" },
+        { id: "gpt-5.4-high", name: "GPT-5.4 High" },
+      ]),
+    });
+
+    await autoRefreshModels(deps);
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const [, writtenConfig] = writeFileSync.mock.calls[0];
+    const parsed = JSON.parse(writtenConfig as string);
+    expect(parsed.provider["cursor-acp"].models).toEqual({
+      auto: { name: "Auto" },
+      "custom-model": { name: "Custom" },
+      "gpt-5.4-high": { name: "GPT-5.4 High" },
+    });
+  });
+
+  it("can disable startup model refresh", async () => {
+    const { deps, readFileSync, writeFileSync, discoverModels } = createDeps({
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG: "/tmp/opencode.json",
+        CURSOR_ACP_MODEL_AUTO_REFRESH: "false",
+      },
+    });
+
+    await autoRefreshModels(deps);
+
+    expect(readFileSync).not.toHaveBeenCalled();
+    expect(discoverModels).not.toHaveBeenCalled();
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("uses compact variant sync only when explicitly requested", async () => {
+    const { deps, writeFileSync } = createDeps({
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG: "/tmp/opencode.json",
+        CURSOR_ACP_MODEL_AUTO_REFRESH: "compact",
+      },
+      readFileSync: vi.fn(() =>
+        JSON.stringify({
+          provider: {
+            "cursor-acp": {
+              models: {
+                auto: { name: "Auto" },
+                "custom-model": { name: "Custom" },
+                "gpt-5.4-low": { name: "Old Low" },
+                "gpt-5.4-high": { name: "Old High" },
+              },
+            },
+          },
+        }),
+      ),
+      discoverModels: vi.fn(async () => [
+        { id: "auto", name: "Auto" },
+        { id: "gpt-5.4", name: "GPT-5.4" },
+        { id: "gpt-5.4-low", name: "GPT-5.4 Low" },
+        { id: "gpt-5.4-high", name: "GPT-5.4 High" },
+      ]),
+    });
+
+    await autoRefreshModels(deps);
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const [, writtenConfig] = writeFileSync.mock.calls[0];
+    const parsed = JSON.parse(writtenConfig as string);
+    expect(parsed.provider["cursor-acp"].models).toMatchObject({
+      auto: { name: "Auto" },
+      "custom-model": { name: "Custom" },
+      "gpt-5.4": {
+        name: "GPT-5.4",
+        options: { cursorModel: "gpt-5.4" },
+        variants: {
+          low: { cursorModel: "gpt-5.4-low" },
+          high: { cursorModel: "gpt-5.4-high" },
+        },
+      },
+    });
+    expect(parsed.provider["cursor-acp"].models["gpt-5.4-low"]).toBeUndefined();
+    expect(parsed.provider["cursor-acp"].models["gpt-5.4-high"]).toBeUndefined();
+  });
+
   it("returns silently when the config file is missing", async () => {
     const { deps, readFileSync, writeFileSync, discoverModels } = createDeps({
       existsSync: vi.fn(() => false),

--- a/tests/unit/models/sync.test.ts
+++ b/tests/unit/models/sync.test.ts
@@ -180,6 +180,46 @@ describe("models/sync", () => {
     expect(parsed.provider["cursor-acp"].models["gpt-5.4-high"]).toBeUndefined();
   });
 
+  it("writes compact refresh updates even when no model ids are added or removed", async () => {
+    const { deps, writeFileSync } = createDeps({
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG: "/tmp/opencode.json",
+        CURSOR_ACP_MODEL_AUTO_REFRESH: "compact",
+      },
+      readFileSync: vi.fn(() =>
+        JSON.stringify({
+          provider: {
+            "cursor-acp": {
+              models: {
+                "gpt-5.4": {
+                  name: "Old GPT-5.4",
+                  options: { cursorModel: "gpt-5.4" },
+                  variants: {
+                    low: { cursorModel: "gpt-5.4-low" },
+                    high: { cursorModel: "gpt-5.4-high" },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      ),
+      discoverModels: vi.fn(async () => [
+        { id: "gpt-5.4", name: "GPT-5.4" },
+        { id: "gpt-5.4-low", name: "GPT-5.4 Low" },
+        { id: "gpt-5.4-high", name: "GPT-5.4 High" },
+      ]),
+    });
+
+    await autoRefreshModels(deps);
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const [, writtenConfig] = writeFileSync.mock.calls[0];
+    const parsed = JSON.parse(writtenConfig as string);
+    expect(parsed.provider["cursor-acp"].models["gpt-5.4"].name).toBe("GPT-5.4");
+  });
+
   it("returns silently when the config file is missing", async () => {
     const { deps, readFileSync, writeFileSync, discoverModels } = createDeps({
       existsSync: vi.fn(() => false),


### PR DESCRIPTION
Follow-up to #81.

This keeps the useful part of Akshay's PR but adapts it to current main:

- keeps the current SDK-runner model discovery path
- keeps startup model refresh additive by default
- adds CURSOR_ACP_MODEL_AUTO_REFRESH=false to disable startup refresh
- adds CURSOR_ACP_MODEL_AUTO_REFRESH=compact for opt-in compact variants
- documents the env options in the readme

I added Akshay as co-author on the commit since this is derived from the approach in #81.

Verification:
- npm run build
- npm test -- tests/unit/models/sync.test.ts tests/unit/models/variants.test.ts