### PR TITLE
Respect OPENCODE_CONFIG in open-cursor CLI

### DIFF
--- a/src/cli/opencode-cursor.ts
+++ b/src/cli/opencode-cursor.ts
@@ -366,7 +366,7 @@ Commands:
   help        Show this help message
 
 Options:
-  --config <path>       Path to opencode.json (default: ~/.config/opencode/opencode.json)
+  --config <path>       Path to opencode.json (default: OPENCODE_CONFIG or ~/.config/opencode/opencode.json)
   --plugin-dir <path>   Path to plugin directory (default: ~/.config/opencode/plugin)
   --base-url <url>      Proxy base URL (default: http://127.0.0.1:32124/v1)
   --copy                Copy plugin instead of symlink
@@ -444,9 +444,9 @@ function getConfigHome(): string {
   return join(homedir(), ".config");
 }
 
-function resolvePaths(options: Options) {
+export function resolvePaths(options: Options) {
   const opencodeDir = join(getConfigHome(), "opencode");
-  const configPath = resolve(options.config || join(opencodeDir, "opencode.json"));
+  const configPath = resolve(options.config || process.env.OPENCODE_CONFIG || join(opencodeDir, "opencode.json"));
   const pluginDir = resolve(options.pluginDir || join(opencodeDir, "plugin"));
   const pluginPath = join(pluginDir, `${PROVIDER_ID}.js`);
   return { opencodeDir, configPath, pluginDir, pluginPath };

--- a/tests/unit/cli/opencode-cursor.test.ts
+++ b/tests/unit/cli/opencode-cursor.test.ts
@@ -14,6 +14,7 @@ import {
   explainCursorModels,
   summarizeModelSync,
   isCliEntrypoint,
+  resolvePaths,
 } from "../../../src/cli/opencode-cursor.js";
 
 describe("cli/opencode-cursor entrypoint", () => {
@@ -125,6 +126,41 @@ describe("cli/opencode-cursor status", () => {
     expect(result).toHaveProperty("plugin");
     expect(result).toHaveProperty("provider");
     expect(result).toHaveProperty("aiSdk");
+  });
+});
+
+describe("cli/opencode-cursor path resolution", () => {
+  it("uses OPENCODE_CONFIG when --config is not provided", () => {
+    const originalConfig = process.env.OPENCODE_CONFIG;
+    const customConfig = join(tmpdir(), "cursor-models.json");
+    process.env.OPENCODE_CONFIG = customConfig;
+
+    try {
+      expect(resolvePaths({}).configPath).toBe(resolve(customConfig));
+    } finally {
+      if (originalConfig === undefined) {
+        delete process.env.OPENCODE_CONFIG;
+      } else {
+        process.env.OPENCODE_CONFIG = originalConfig;
+      }
+    }
+  });
+
+  it("prefers --config over OPENCODE_CONFIG", () => {
+    const originalConfig = process.env.OPENCODE_CONFIG;
+    const envConfig = join(tmpdir(), "env-opencode.json");
+    const flagConfig = join(tmpdir(), "flag-opencode.json");
+    process.env.OPENCODE_CONFIG = envConfig;
+
+    try {
+      expect(resolvePaths({ config: flagConfig }).configPath).toBe(resolve(flagConfig));
+    } finally {
+      if (originalConfig === undefined) {
+        delete process.env.OPENCODE_CONFIG;
+      } else {
+        process.env.OPENCODE_CONFIG = originalConfig;
+      }
+    }
   });
 });
 

--- a/tests/unit/cli/opencode-cursor.test.ts
+++ b/tests/unit/cli/opencode-cursor.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/cli/opencode-cursor.test.ts
 import { describe, expect, it } from "bun:test";
 import { closeSync, mkdtempSync, openSync, rmSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -130,6 +130,22 @@ describe("cli/opencode-cursor status", () => {
 });
 
 describe("cli/opencode-cursor path resolution", () => {
+  it("uses the default config path when no config is provided", () => {
+    const originalConfig = process.env.OPENCODE_CONFIG;
+    const expectedConfig = join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "opencode", "opencode.json");
+    delete process.env.OPENCODE_CONFIG;
+
+    try {
+      expect(resolvePaths({}).configPath).toBe(resolve(expectedConfig));
+    } finally {
+      if (originalConfig === undefined) {
+        delete process.env.OPENCODE_CONFIG;
+      } else {
+        process.env.OPENCODE_CONFIG = originalConfig;
+      }
+    }
+  });
+
   it("uses OPENCODE_CONFIG when --config is not provided", () => {
     const originalConfig = process.env.OPENCODE_CONFIG;
     const customConfig = join(tmpdir(), "cursor-models.json");


### PR DESCRIPTION
## Summary
- Honor OPENCODE_CONFIG when open-cursor CLI commands resolve the config path
- Preserve --config as the highest-precedence override
- Update help text and add CLI path resolution tests

## Tests
- bun test tests/unit/cli/opencode-cursor.test.ts
- bun test tests/unit/plugin-toggle.test.ts

Note: bun test tests/unit/models/sync.test.ts currently exits 1 locally without diagnostic output; this test file is outside the CLI resolver change.