### PR TITLE
perf: reduce per-event allocations in streaming pipeline

### DIFF
--- a/src/client/sdk-child.ts
+++ b/src/client/sdk-child.ts
@@ -33,6 +33,10 @@ import { randomBytes } from "node:crypto";
 
 const log = createLogger("sdk-child");
 
+// ─── Shared encoder (avoid per-event allocation) ────────────────────────────
+
+const textEncoder = new TextEncoder();
+
 // ─── Utilities ──────────────────────────────────────────────────────────────
 
 /**
@@ -250,9 +254,8 @@ class SdkRunnerSingleton {
           pending.promiseResolver(wrapped.exitCode ?? 0);
           this.pendingRequests.delete(requestId);
         } else if (wrapped.event) {
-          // Emit unwrapped event
-          const event = JSON.stringify(wrapped.event) + "\n";
-          pending.controller.enqueue(new TextEncoder().encode(event));
+          const eventLine = JSON.stringify(wrapped.event) + "\n";
+          pending.controller.enqueue(textEncoder.encode(eventLine));
         }
       } catch (err) {
         log.error("Failed to parse wrapped response line", {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -17,7 +17,9 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
   error: 3,
 };
 
-function getConfiguredLevel(): LogLevel {
+// Cache env-derived config at module load — these don't change at runtime
+// and process.env access is surprisingly expensive per-call.
+function readConfiguredLevel(): LogLevel {
   const env = process.env.CURSOR_ACP_LOG_LEVEL?.toLowerCase();
   if (env && env in LEVEL_PRIORITY) {
     return env as LogLevel;
@@ -25,19 +27,21 @@ function getConfiguredLevel(): LogLevel {
   return "info";
 }
 
-function isSilent(): boolean {
-  return process.env.CURSOR_ACP_LOG_SILENT === "1" ||
-         process.env.CURSOR_ACP_LOG_SILENT === "true";
-}
+let CONFIGURED_LEVEL: LogLevel = readConfiguredLevel();
+let IS_SILENT: boolean =
+  process.env.CURSOR_ACP_LOG_SILENT === "1" ||
+  process.env.CURSOR_ACP_LOG_SILENT === "true";
+let CONSOLE_ENABLED: boolean =
+  process.env.CURSOR_ACP_LOG_CONSOLE === "1" ||
+  process.env.CURSOR_ACP_LOG_CONSOLE === "true";
+let CONFIGURED_PRIORITY = LEVEL_PRIORITY[CONFIGURED_LEVEL];
 
 function shouldLog(level: LogLevel): boolean {
-  if (isSilent()) return false;
-  const configured = getConfiguredLevel();
-  return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[configured];
+  if (IS_SILENT) return false;
+  return LEVEL_PRIORITY[level] >= CONFIGURED_PRIORITY;
 }
 
 function formatMessage(level: LogLevel, component: string, message: string, data?: unknown): string {
-  const timestamp = new Date().toISOString();
   const prefix = `[cursor-acp:${component}]`;
   const levelTag = level.toUpperCase().padEnd(5);
 
@@ -54,11 +58,6 @@ function formatMessage(level: LogLevel, component: string, message: string, data
   return formatted;
 }
 
-function isConsoleEnabled(): boolean {
-  const consoleEnv = process.env.CURSOR_ACP_LOG_CONSOLE;
-  return consoleEnv === "1" || consoleEnv === "true";
-}
-
 let logDirEnsured = false;
 let logFileError = false;
 
@@ -66,6 +65,14 @@ let logFileError = false;
 export function _resetLoggerState(): void {
   logDirEnsured = false;
   logFileError = false;
+  CONFIGURED_LEVEL = readConfiguredLevel();
+  IS_SILENT =
+    process.env.CURSOR_ACP_LOG_SILENT === "1" ||
+    process.env.CURSOR_ACP_LOG_SILENT === "true";
+  CONSOLE_ENABLED =
+    process.env.CURSOR_ACP_LOG_CONSOLE === "1" ||
+    process.env.CURSOR_ACP_LOG_CONSOLE === "true";
+  CONFIGURED_PRIORITY = LEVEL_PRIORITY[CONFIGURED_LEVEL];
 }
 
 function ensureLogDir(): void {
@@ -122,25 +129,25 @@ export function createLogger(component: string): Logger {
       if (!shouldLog("debug")) return;
       const formatted = formatMessage("debug", component, message, data);
       writeToFile(formatted);
-      if (isConsoleEnabled()) console.error(formatted);
+      if (CONSOLE_ENABLED) console.error(formatted);
     },
     info: (message: string, data?: unknown) => {
       if (!shouldLog("info")) return;
       const formatted = formatMessage("info", component, message, data);
       writeToFile(formatted);
-      if (isConsoleEnabled()) console.error(formatted);
+      if (CONSOLE_ENABLED) console.error(formatted);
     },
     warn: (message: string, data?: unknown) => {
       if (!shouldLog("warn")) return;
       const formatted = formatMessage("warn", component, message, data);
       writeToFile(formatted);
-      if (isConsoleEnabled()) console.error(formatted);
+      if (CONSOLE_ENABLED) console.error(formatted);
     },
     error: (message: string, data?: unknown) => {
       if (!shouldLog("error")) return;
       const formatted = formatMessage("error", component, message, data);
       writeToFile(formatted);
-      if (isConsoleEnabled()) console.error(formatted);
+      if (CONSOLE_ENABLED) console.error(formatted);
     },
   };
 }

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -27,11 +27,11 @@ describe("logger", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    _resetLoggerState(); // Reset module-level state before each test
     process.env = { ...originalEnv };
     delete process.env.CURSOR_ACP_LOG_LEVEL;
     delete process.env.CURSOR_ACP_LOG_SILENT;
     delete process.env.CURSOR_ACP_LOG_CONSOLE;
+    _resetLoggerState();
   });
 
   afterEach(() => {
@@ -106,6 +106,46 @@ describe("logger", () => {
       const log = createLogger("test");
       log.info("test message");
 
+      expect(mockedFs.appendFileSync).not.toHaveBeenCalled();
+    });
+
+    it("respects cached CURSOR_ACP_LOG_LEVEL after _resetLoggerState", () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
+
+      process.env.CURSOR_ACP_LOG_LEVEL = "warn";
+      _resetLoggerState();
+
+      const log = createLogger("test");
+      log.info("filtered info");
+      log.warn("allowed warn");
+
+      expect(mockedFs.appendFileSync).toHaveBeenCalledTimes(1);
+      expect(mockedFs.appendFileSync).toHaveBeenCalledWith(
+        expect.stringContaining("plugin.log"),
+        expect.stringMatching(/\[cursor-acp:test\] WARN\s+allowed warn/),
+      );
+    });
+
+    it("refreshes cached log level when env changes and _resetLoggerState is called", () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
+
+      process.env.CURSOR_ACP_LOG_LEVEL = "debug";
+      _resetLoggerState();
+
+      const log = createLogger("test");
+      log.debug("debug while enabled");
+      expect(mockedFs.appendFileSync).toHaveBeenCalledTimes(1);
+
+      vi.clearAllMocks();
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
+
+      process.env.CURSOR_ACP_LOG_LEVEL = "error";
+      _resetLoggerState();
+
+      log.debug("debug after level raised");
       expect(mockedFs.appendFileSync).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -70,6 +70,7 @@ describe("logger", () => {
 
     it("writes to console only when CURSOR_ACP_LOG_CONSOLE=1", () => {
       process.env.CURSOR_ACP_LOG_CONSOLE = "1";
+      _resetLoggerState();
       mockedFs.existsSync.mockReturnValue(true);
       mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -98,6 +99,7 @@ describe("logger", () => {
 
     it("respects CURSOR_ACP_LOG_SILENT", () => {
       process.env.CURSOR_ACP_LOG_SILENT = "1";
+      _resetLoggerState();
       mockedFs.existsSync.mockReturnValue(true);
       mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
 


### PR DESCRIPTION
## Summary

- **sdk-child.ts**: Module-level `TextEncoder` singleton instead of `new TextEncoder()` on every streamed event. Eliminates object allocation churn on the hot path.
- **logger.ts**: Cache `CURSOR_ACP_LOG_LEVEL`, `CURSOR_ACP_LOG_SILENT`, and `CURSOR_ACP_LOG_CONSOLE` at module load. Replaces per-call `process.env` reads in `shouldLog()` and `isConsoleEnabled()` with cached constants. `_resetLoggerState()` re-reads env for tests.
- **logger.test.ts**: Tests that set env vars now call `_resetLoggerState()` after so cached values pick them up.

Relates to #92 — this is the first of two PRs targeting quick wins from the performance audit. These are internal-only changes with no API or behaviour impact.

## What this does NOT change

- No tracker swap (`MixedDeltaTracker` stays — [git history shows](https://github.com/Nomadcxx/opencode-cursor/commit/c113081) it exists to handle mixed delta/accumulated streams and swapping it would reintroduce duplicate output)
- No HTTP contract changes
- No tool-loop or provider boundary changes

## Test plan

- [x] Full test suite: 644 pass, 0 fail, 2 skip (pre-existing)
- [x] `npm run build` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized event message handling and logging configuration evaluation.

* **Tests**
  * Enhanced logger configuration test coverage, including environment variable scenarios and state reset validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->