### PR TITLE
perf: reduce per-request overhead in proxy handler

### DIFF
--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -93,6 +93,14 @@ export function readMcpConfigs(deps: ReadMcpConfigsDeps = {}): McpServerConfig[]
   return configs;
 }
 
+let _subagentCache: { names: string[]; expiry: number } | null = null;
+const SUBAGENT_CACHE_TTL_MS = 60_000;
+
+/** Clear cached subagent names (for testing only). */
+export function _resetSubagentCache(): void {
+  _subagentCache = null;
+}
+
 interface ReadSubagentNamesDeps {
   configJson?: string;
   existsSync?: (path: string) => boolean;
@@ -101,6 +109,20 @@ interface ReadSubagentNamesDeps {
 }
 
 export function readSubagentNames(deps: ReadSubagentNamesDeps = {}): string[] {
+  const useCache = !deps.configJson;
+  if (useCache && _subagentCache && Date.now() < _subagentCache.expiry) {
+    return _subagentCache.names;
+  }
+
+  const result = readSubagentNamesUncached(deps);
+
+  if (useCache) {
+    _subagentCache = { names: result, expiry: Date.now() + SUBAGENT_CACHE_TTL_MS };
+  }
+  return result;
+}
+
+function readSubagentNamesUncached(deps: ReadSubagentNamesDeps): string[] {
   let raw: string;
 
   if (deps.configJson != null) {

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -109,7 +109,7 @@ interface ReadSubagentNamesDeps {
 }
 
 export function readSubagentNames(deps: ReadSubagentNamesDeps = {}): string[] {
-  const useCache = !deps.configJson;
+  const useCache = deps.configJson == null;
   if (useCache && _subagentCache && Date.now() < _subagentCache.expiry) {
     return _subagentCache.names;
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1303,10 +1303,11 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
       }
 
       log.debug("Proxy request (node)", { method: req.method, path: url.pathname });
-      let body = "";
+      const bodyChunks: Buffer[] = [];
       for await (const chunk of req) {
-        body += chunk;
+        bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
       }
+      const body = Buffer.concat(bodyChunks).toString("utf8");
 
       const bodyData: any = JSON.parse(body || "{}");
       const messages: Array<any> = Array.isArray(bodyData?.messages) ? bodyData.messages : [];
@@ -1317,8 +1318,10 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
       const toolLoopGuard = createToolLoopGuard(messages, TOOL_LOOP_MAX_REPEAT);
       const boundaryContext = createBoundaryRuntimeContext("node-handler");
 
+      const reqPerf = new RequestPerf(`node-${Date.now()}`);
       const subagentNames = readSubagentNames();
       const prompt = buildPromptFromMessages(messages, tools, subagentNames);
+      reqPerf.mark("prompt-built");
       const model = boundaryContext.run("resolveRuntimeModel", (boundary) =>
         boundary.resolveRuntimeModel(bodyData?.model, bodyData?.cursorModel),
       );
@@ -1342,6 +1345,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
       const authHeaderNode = req.headers["authorization"] as string | undefined;
       const sdkApiKeyNode = resolveRequestSdkApiKey(authHeaderNode);
       const backend = resolveBackendForRequest(sdkApiKeyNode);
+      reqPerf.mark("backend-resolved");
       if (backend === "sdk" && !sdkApiKeyNode) {
         res.writeHead(401, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Cursor SDK backend requires a real Cursor API key. Set CURSOR_API_KEY or run `opencode auth login`; the legacy `cursor-agent` placeholder is not valid SDK auth." }));
@@ -1454,8 +1458,8 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
         const id = `cursor-acp-${Date.now()}`;
         const created = Math.floor(Date.now() / 1000);
-        const perf = new RequestPerf(id);
-        perf.mark("spawn");
+        const perf = reqPerf;
+        perf.mark("child-spawned");
 
         const converter = new StreamToSseConverter(model, { id, created });
         const lineBuffer = new LineBuffer();

--- a/src/proxy/prompt-builder.ts
+++ b/src/proxy/prompt-builder.ts
@@ -8,48 +8,50 @@ const log = createLogger("proxy:prompt-builder");
  * plain text flattening would silently drop.
  */
 export function buildPromptFromMessages(messages: Array<any>, tools: Array<any>, subagentNames: string[] = []): string {
-  const messageSummary = messages.map((m: any, i: number) => {
-    const role = m?.role ?? "?";
-    const hasToolCalls = Array.isArray(m?.tool_calls) ? m.tool_calls.length : 0;
-    const tcNames = hasToolCalls > 0 ? m.tool_calls.map((tc: any) => tc?.function?.name).join(",") : "";
-    const contentType = typeof m?.content;
-    const contentLen = typeof m?.content === "string" ? m.content.length : Array.isArray(m?.content) ? `arr:${m.content.length}` : "null";
-    const toolCallId = m?.tool_call_id ?? null;
-    return { i, role, hasToolCalls, tcNames, contentType, contentLen, toolCallId };
-  });
+  if (log.isDebugEnabled()) {
+    const messageSummary = messages.map((m: any, i: number) => {
+      const role = m?.role ?? "?";
+      const hasToolCalls = Array.isArray(m?.tool_calls) ? m.tool_calls.length : 0;
+      const tcNames = hasToolCalls > 0 ? m.tool_calls.map((tc: any) => tc?.function?.name).join(",") : "";
+      const contentType = typeof m?.content;
+      const contentLen = typeof m?.content === "string" ? m.content.length : Array.isArray(m?.content) ? `arr:${m.content.length}` : "null";
+      const toolCallId = m?.tool_call_id ?? null;
+      return { i, role, hasToolCalls, tcNames, contentType, contentLen, toolCallId };
+    });
 
-  const assistantWithToolCalls = messages.filter((m: any) => m?.role === "assistant" && Array.isArray(m?.tool_calls) && m.tool_calls.length > 0);
-  const assistantEmpty = messages.filter((m: any) => m?.role === "assistant" && (!m?.tool_calls || m.tool_calls.length === 0) && (!m?.content || m.content === "" || m.content === null));
-  const toolResults = messages.filter((m: any) => m?.role === "tool");
+    const assistantWithToolCalls = messages.filter((m: any) => m?.role === "assistant" && Array.isArray(m?.tool_calls) && m.tool_calls.length > 0);
+    const assistantEmpty = messages.filter((m: any) => m?.role === "assistant" && (!m?.tool_calls || m.tool_calls.length === 0) && (!m?.content || m.content === "" || m.content === null));
+    const toolResults = messages.filter((m: any) => m?.role === "tool");
 
-  log.debug("buildPromptFromMessages", {
-    totalMessages: messages.length,
-    totalTools: tools.length,
-    messageSummary,
-    stats: {
-      assistantWithToolCalls: assistantWithToolCalls.length,
-      assistantEmpty: assistantEmpty.length,
-      toolResults: toolResults.length,
-    },
-    assistantDetails: assistantWithToolCalls.length > 0 ? assistantWithToolCalls.map((m: any, i: number) => ({
-      index: i,
-      toolCallCount: Array.isArray(m?.tool_calls) ? m.tool_calls.length : 0,
-      toolCallIds: Array.isArray(m?.tool_calls) ? m.tool_calls.map((tc: any) => tc?.id).join(",") : "",
-      toolCallNames: Array.isArray(m?.tool_calls) ? m.tool_calls.map((tc: any) => tc?.function?.name).join(",") : "",
-      contentType: typeof m?.content,
-      contentPreview: typeof m?.content === "string" ? m.content.slice(0, 50) : typeof m?.content,
-    })) : [],
-    emptyAssistantDetails: assistantEmpty.length > 0 ? assistantEmpty.map((m: any, i: number) => ({
-      index: i,
-      contentType: typeof m?.content,
-      contentPreview: typeof m?.content === "string" ? m.content.slice(0, 50) : typeof m?.content,
-    })) : [],
-    toolResultDetails: toolResults.length > 0 ? toolResults.map((m: any, i: number) => ({
-      index: i,
-      toolCallId: m?.tool_call_id,
-      contentPreview: typeof m?.content === "string" ? m.content.slice(0, 100) : typeof m?.content,
-    })) : [],
-  });
+    log.debug("buildPromptFromMessages", {
+      totalMessages: messages.length,
+      totalTools: tools.length,
+      messageSummary,
+      stats: {
+        assistantWithToolCalls: assistantWithToolCalls.length,
+        assistantEmpty: assistantEmpty.length,
+        toolResults: toolResults.length,
+      },
+      assistantDetails: assistantWithToolCalls.length > 0 ? assistantWithToolCalls.map((m: any, i: number) => ({
+        index: i,
+        toolCallCount: Array.isArray(m?.tool_calls) ? m.tool_calls.length : 0,
+        toolCallIds: Array.isArray(m?.tool_calls) ? m.tool_calls.map((tc: any) => tc?.id).join(",") : "",
+        toolCallNames: Array.isArray(m?.tool_calls) ? m.tool_calls.map((tc: any) => tc?.function?.name).join(",") : "",
+        contentType: typeof m?.content,
+        contentPreview: typeof m?.content === "string" ? m.content.slice(0, 50) : typeof m?.content,
+      })) : [],
+      emptyAssistantDetails: assistantEmpty.length > 0 ? assistantEmpty.map((m: any, i: number) => ({
+        index: i,
+        contentType: typeof m?.content,
+        contentPreview: typeof m?.content === "string" ? m.content.slice(0, 50) : typeof m?.content,
+      })) : [],
+      toolResultDetails: toolResults.length > 0 ? toolResults.map((m: any, i: number) => ({
+        index: i,
+        toolCallId: m?.tool_call_id,
+        contentPreview: typeof m?.content === "string" ? m.content.slice(0, 100) : typeof m?.content,
+      })) : [],
+    });
+  }
 
   const lines: string[] = [];
 

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -114,10 +114,12 @@ export interface Logger {
   info: (message: string, data?: unknown) => void;
   warn: (message: string, data?: unknown) => void;
   error: (message: string, data?: unknown) => void;
+  isDebugEnabled: () => boolean;
 }
 
 export function createLogger(component: string): Logger {
   return {
+    isDebugEnabled: () => shouldLog("debug"),
     debug: (message: string, data?: unknown) => {
       if (!shouldLog("debug")) return;
       const formatted = formatMessage("debug", component, message, data);

--- a/tests/unit/mcp-config.test.ts
+++ b/tests/unit/mcp-config.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect } from "bun:test";
-import { readSubagentNames } from "../../src/mcp/config.js";
+import { describe, it, expect, beforeEach } from "bun:test";
+import { readSubagentNames, _resetSubagentCache } from "../../src/mcp/config.js";
 
 describe("readSubagentNames", () => {
+  beforeEach(() => {
+    _resetSubagentCache();
+  });
   it("returns only mode:subagent agents when some exist", () => {
     const config = JSON.stringify({
       agent: {
@@ -39,5 +42,48 @@ describe("readSubagentNames", () => {
 
   it("returns general-purpose when config is malformed JSON", () => {
     expect(readSubagentNames({ configJson: "{ bad json" })).toEqual(["general-purpose"]);
+  });
+
+  it("caches filesystem results across calls", () => {
+    let readCount = 0;
+    const deps = {
+      existsSync: () => true,
+      readFileSync: () => {
+        readCount++;
+        return JSON.stringify({ agent: { bot: { mode: "subagent" } } });
+      },
+      env: { OPENCODE_CONFIG: "/tmp/test.json" } as NodeJS.ProcessEnv,
+    };
+
+    const first = readSubagentNames(deps);
+    const second = readSubagentNames(deps);
+    expect(first).toEqual(["bot"]);
+    expect(second).toEqual(["bot"]);
+    expect(readCount).toBe(1);
+  });
+
+  it("bypasses cache when configJson is provided", () => {
+    const config1 = JSON.stringify({ agent: { a: { mode: "subagent" } } });
+    const config2 = JSON.stringify({ agent: { b: { mode: "subagent" } } });
+
+    expect(readSubagentNames({ configJson: config1 })).toEqual(["a"]);
+    expect(readSubagentNames({ configJson: config2 })).toEqual(["b"]);
+  });
+
+  it("returns fresh data after cache reset", () => {
+    let callNum = 0;
+    const deps = {
+      existsSync: () => true,
+      readFileSync: () => {
+        callNum++;
+        const name = callNum === 1 ? "first" : "second";
+        return JSON.stringify({ agent: { [name]: { mode: "subagent" } } });
+      },
+      env: { OPENCODE_CONFIG: "/tmp/test.json" } as NodeJS.ProcessEnv,
+    };
+
+    expect(readSubagentNames(deps)).toEqual(["first"]);
+    _resetSubagentCache();
+    expect(readSubagentNames(deps)).toEqual(["second"]);
   });
 });

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -125,4 +125,26 @@ describe("logger", () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe("isDebugEnabled", () => {
+    it("returns false at default log level (info)", () => {
+      const log = createLogger("test");
+      expect(log.isDebugEnabled()).toBe(false);
+    });
+
+    it("returns true when log level is debug", () => {
+      process.env.CURSOR_ACP_LOG_LEVEL = "debug";
+      _resetLoggerState();
+      const log = createLogger("test");
+      expect(log.isDebugEnabled()).toBe(true);
+    });
+
+    it("returns false when silent", () => {
+      process.env.CURSOR_ACP_LOG_LEVEL = "debug";
+      process.env.CURSOR_ACP_LOG_SILENT = "1";
+      _resetLoggerState();
+      const log = createLogger("test");
+      expect(log.isDebugEnabled()).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Cache `readSubagentNames()` with a 60s TTL — eliminates synchronous `readFileSync` on every chat turn
- Guard prompt-builder debug diagnostics behind `log.isDebugEnabled()` — skips 4 array passes over messages when debug logging is off (the common case)
- Fix Node HTTP body read from O(n^2) string concat (`body += chunk`) to `Buffer.concat`
- Add `RequestPerf` marks for `prompt-built`, `backend-resolved`, and `child-spawned` phases for better timing observability

Part of #92

## Test plan

- [x] Full test suite passes (644/644)
- [x] Build succeeds
- [ ] Manual verification: debug logging off → prompt-builder skips diagnostic work
- [ ] Manual verification: subagent cache hit on consecutive requests within 60s