### PR TITLE
perf: replace synchronous file logging with write stream

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -122,7 +122,9 @@ function rotateIfNeeded(): void {
     logBytesWritten = 0;
     openLogStream();
   } catch {
-    // Rotation failed — keep writing to current file
+    if (!logFileError && !logStream) {
+      openLogStream();
+    }
   }
 }
 
@@ -133,6 +135,7 @@ function writeToFile(message: string): void {
   if (logFileError || !logStream) return;
 
   rotateIfNeeded();
+  if (logFileError || !logStream) return;
 
   const timestamp = new Date().toISOString();
   const line = `${timestamp} ${message}\n`;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -37,7 +37,6 @@ function shouldLog(level: LogLevel): boolean {
 }
 
 function formatMessage(level: LogLevel, component: string, message: string, data?: unknown): string {
-  const timestamp = new Date().toISOString();
   const prefix = `[cursor-acp:${component}]`;
   const levelTag = level.toUpperCase().padEnd(5);
 
@@ -61,11 +60,18 @@ function isConsoleEnabled(): boolean {
 
 let logDirEnsured = false;
 let logFileError = false;
+let logStream: fs.WriteStream | null = null;
+let logBytesWritten = 0;
 
 /** Reset internal state (for testing only) */
 export function _resetLoggerState(): void {
   logDirEnsured = false;
   logFileError = false;
+  if (logStream) {
+    logStream.end();
+    logStream = null;
+  }
+  logBytesWritten = 0;
 }
 
 function ensureLogDir(): void {
@@ -80,33 +86,58 @@ function ensureLogDir(): void {
   }
 }
 
-function rotateIfNeeded(): void {
+function openLogStream(): void {
+  if (logStream || logFileError) return;
+  ensureLogDir();
+  if (logFileError) return;
+
   try {
-    const stats = fs.statSync(LOG_FILE);
-    if (stats.size >= MAX_LOG_SIZE) {
-      const backupFile = LOG_FILE + ".1";
-      fs.renameSync(LOG_FILE, backupFile);
+    // Seed byte counter from existing file size
+    try {
+      logBytesWritten = fs.statSync(LOG_FILE).size;
+    } catch {
+      logBytesWritten = 0;
     }
+    logStream = fs.createWriteStream(LOG_FILE, { flags: "a" });
+    logStream.on("error", () => {
+      if (!logFileError) {
+        logFileError = true;
+        console.error(`[cursor-acp] Failed to write logs. Using: ${LOG_FILE}`);
+      }
+      logStream = null;
+    });
   } catch {
+    logFileError = true;
+  }
+}
+
+function rotateIfNeeded(): void {
+  if (logBytesWritten < MAX_LOG_SIZE) return;
+  try {
+    if (logStream) {
+      logStream.end();
+      logStream = null;
+    }
+    fs.renameSync(LOG_FILE, LOG_FILE + ".1");
+    logBytesWritten = 0;
+    openLogStream();
+  } catch {
+    // Rotation failed — keep writing to current file
   }
 }
 
 function writeToFile(message: string): void {
   if (logFileError) return;
 
-  ensureLogDir();
-  if (logFileError) return;
+  if (!logStream) openLogStream();
+  if (logFileError || !logStream) return;
 
-  try {
-    rotateIfNeeded();
-    const timestamp = new Date().toISOString();
-    fs.appendFileSync(LOG_FILE, `${timestamp} ${message}\n`);
-  } catch {
-    if (!logFileError) {
-      logFileError = true;
-      console.error(`[cursor-acp] Failed to write logs. Using: ${LOG_FILE}`);
-    }
-  }
+  rotateIfNeeded();
+
+  const timestamp = new Date().toISOString();
+  const line = `${timestamp} ${message}\n`;
+  logStream.write(line);
+  logBytesWritten += Buffer.byteLength(line);
 }
 
 export interface Logger {

--- a/tests/unit/utils/logger.test.ts
+++ b/tests/unit/utils/logger.test.ts
@@ -4,20 +4,28 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "bun:test";
 import * as fs from "node:fs";
 import { createLogger, _resetLoggerState } from "../../../src/utils/logger.ts";
 
+const mockWrite = vi.fn().mockReturnValue(true);
+const mockEnd = vi.fn();
+const mockOn = vi.fn().mockReturnThis();
+
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
-  appendFileSync: vi.fn(),
   statSync: vi.fn(),
   renameSync: vi.fn(),
+  createWriteStream: vi.fn(() => ({
+    write: mockWrite,
+    end: mockEnd,
+    on: mockOn,
+  })),
 }));
 
 type MockedFs = {
   existsSync: ReturnType<typeof vi.fn>;
   mkdirSync: ReturnType<typeof vi.fn>;
-  appendFileSync: ReturnType<typeof vi.fn>;
   statSync: ReturnType<typeof vi.fn>;
   renameSync: ReturnType<typeof vi.fn>;
+  createWriteStream: ReturnType<typeof vi.fn>;
 };
 
 const mockedFs = fs as unknown as MockedFs;
@@ -27,11 +35,12 @@ describe("logger", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    _resetLoggerState(); // Reset module-level state before each test
+    _resetLoggerState();
     process.env = { ...originalEnv };
     delete process.env.CURSOR_ACP_LOG_LEVEL;
     delete process.env.CURSOR_ACP_LOG_SILENT;
     delete process.env.CURSOR_ACP_LOG_CONSOLE;
+    mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
   });
 
   afterEach(() => {
@@ -41,7 +50,6 @@ describe("logger", () => {
   describe("file logging", () => {
     it("creates log directory if missing", () => {
       mockedFs.existsSync.mockReturnValue(false);
-      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
 
       const log = createLogger("test");
       log.info("test message");
@@ -52,16 +60,18 @@ describe("logger", () => {
       );
     });
 
-    it("writes logs to file by default (not console)", () => {
+    it("opens a write stream and writes logs (not console)", () => {
       mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const log = createLogger("test");
       log.info("test message");
 
-      expect(mockedFs.appendFileSync).toHaveBeenCalledWith(
+      expect(mockedFs.createWriteStream).toHaveBeenCalledWith(
         expect.stringContaining("plugin.log"),
+        { flags: "a" },
+      );
+      expect(mockWrite).toHaveBeenCalledWith(
         expect.stringMatching(/\[cursor-acp:test\] INFO\s+test message/),
       );
       expect(consoleSpy).not.toHaveBeenCalled();
@@ -71,7 +81,6 @@ describe("logger", () => {
     it("writes to console only when CURSOR_ACP_LOG_CONSOLE=1", () => {
       process.env.CURSOR_ACP_LOG_CONSOLE = "1";
       mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const log = createLogger("test");
@@ -83,7 +92,7 @@ describe("logger", () => {
       consoleSpy.mockRestore();
     });
 
-    it("rotates log file when exceeds 5MB", () => {
+    it("rotates log file when byte counter exceeds 5MB", () => {
       mockedFs.existsSync.mockReturnValue(true);
       mockedFs.statSync.mockReturnValue({ size: 6 * 1024 * 1024 } as fs.Stats);
 
@@ -99,30 +108,25 @@ describe("logger", () => {
     it("respects CURSOR_ACP_LOG_SILENT", () => {
       process.env.CURSOR_ACP_LOG_SILENT = "1";
       mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
 
       const log = createLogger("test");
       log.info("test message");
 
-      expect(mockedFs.appendFileSync).not.toHaveBeenCalled();
+      expect(mockWrite).not.toHaveBeenCalled();
     });
 
-    it("does not crash and falls back to silent if file write fails", () => {
+    it("does not crash if stream creation fails", () => {
       mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.statSync.mockReturnValue({ size: 1000 } as fs.Stats);
-      mockedFs.appendFileSync.mockImplementationOnce(() => {
+      mockedFs.createWriteStream.mockImplementationOnce(() => {
         throw new Error("EACCES");
       });
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
       const log = createLogger("test");
 
       expect(() => log.info("test message")).not.toThrow();
       expect(() => log.info("test message 2")).not.toThrow();
 
-      // First call throws, second call is skipped due to logFileError flag
-      expect(mockedFs.appendFileSync).toHaveBeenCalledTimes(1);
-      consoleSpy.mockRestore();
+      expect(mockWrite).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Replace `fs.appendFileSync` with a persistent `fs.createWriteStream` so log writes no longer block the Node event loop during streaming
- Replace per-log-call `fs.statSync` (rotation check) with an in-memory byte counter — the filesystem is only touched once to seed the initial size
- Rotation closes the stream, renames the file, and reopens cleanly
- Stream errors fall back to silent mode (same behavior as before)

**Git history check**: `appendFileSync` was the initial implementation in `4e0a82f` (debugging tool-loop), not a deliberate sync guarantee. No downstream code depends on synchronous write completion.

Part of #92

## Test plan

- [x] Full test suite passes (644/644)
- [x] Build succeeds
- [x] Tests updated for createWriteStream mock (stream open, write, rotation, silent mode, error handling)
- [ ] Manual: verify plugin.log is written correctly under normal operation