### PR TITLE
fix: harden session resume branch matching

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -33,6 +33,7 @@ import {
   buildSessionKey,
   clearResumeChatId,
   deriveConversationAnchor,
+  deriveConversationResumePrefixes,
   getResumeChatId,
   hasResumeChatId,
   hashForLog,
@@ -283,6 +284,7 @@ export interface ResolvedPrompt {
   sessionKey?: string;
   usedIncremental: boolean;
   contentPrefix?: string;
+  recordContentPrefix?: string;
   toolFingerprint?: string;
   subagentFingerprint?: string;
 }
@@ -323,7 +325,10 @@ export function resolvePromptForBackend(input: {
     });
     return { prompt: getFullPrompt(), usedIncremental: false };
   }
-  const { anchor, contentPrefix } = anchorResult;
+  const { anchor, contentPrefix: anchorContentPrefix } = anchorResult;
+  const resumePrefixes = deriveConversationResumePrefixes(input.messages);
+  const contentPrefix = resumePrefixes?.lookupContentPrefix ?? anchorContentPrefix;
+  const recordContentPrefix = resumePrefixes?.recordContentPrefix ?? contentPrefix;
   const sessionKey = buildSessionKey(input.workspaceDirectory, input.model, anchor);
   const sessionKeyHash = sanitizeSessionKey(sessionKey);
   const toolFingerprint = buildToolFingerprint(input.tools);
@@ -337,7 +342,7 @@ export function resolvePromptForBackend(input: {
         sessionKeyHash,
       });
     }
-    return { prompt: getFullPrompt(), sessionKey, usedIncremental: false, contentPrefix, toolFingerprint, subagentFingerprint };
+    return { prompt: getFullPrompt(), sessionKey, usedIncremental: false, contentPrefix, recordContentPrefix, toolFingerprint, subagentFingerprint };
   }
 
   const incremental = buildIncrementalPrompt(input.messages);
@@ -355,14 +360,14 @@ export function resolvePromptForBackend(input: {
         fullPromptChars: getFullPrompt().length,
       });
     }
-    return { prompt: incremental, resumeChatId, sessionKey, usedIncremental: true, contentPrefix, toolFingerprint, subagentFingerprint };
+    return { prompt: incremental, resumeChatId, sessionKey, usedIncremental: true, contentPrefix, recordContentPrefix, toolFingerprint, subagentFingerprint };
   }
 
   log.info("Session resume active but incremental prompt unavailable; using full prompt", {
     sessionKeyHash,
     resumeChatIdHash,
   });
-  return { prompt: getFullPrompt(), resumeChatId, sessionKey, usedIncremental: false, contentPrefix, toolFingerprint, subagentFingerprint };
+  return { prompt: getFullPrompt(), resumeChatId, sessionKey, usedIncremental: false, contentPrefix, recordContentPrefix, toolFingerprint, subagentFingerprint };
 }
 
 /**
@@ -1166,6 +1171,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
         sessionKey: sessionResumeKey,
         usedIncremental,
         contentPrefix: sessionResumeContentPrefix,
+        recordContentPrefix: sessionResumeRecordContentPrefix,
         toolFingerprint: sessionResumeToolFingerprint,
         subagentFingerprint: sessionResumeSubagentFingerprint,
       } = resolvePromptForBackend({
@@ -1229,14 +1235,14 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
           sessionResumeKey,
           model,
           workspaceDirectory,
-          sessionResumeContentPrefix,
+          sessionResumeRecordContentPrefix,
           sessionResumeToolFingerprint,
           sessionResumeSubagentFingerprint,
         );
         warnIfResumeNotCaptured(
           sessionResumeKey,
           sessionResumeKeyHash,
-          sessionResumeContentPrefix,
+          sessionResumeRecordContentPrefix,
           sessionResumeToolFingerprint,
           sessionResumeSubagentFingerprint,
           model,
@@ -1390,7 +1396,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
                   sessionResumeKey,
                   model,
                   workspaceDirectory,
-                  sessionResumeContentPrefix,
+                  sessionResumeRecordContentPrefix,
                   sessionResumeToolFingerprint,
                   sessionResumeSubagentFingerprint,
                 );
@@ -1470,7 +1476,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
                 sessionResumeKey,
                 model,
                 workspaceDirectory,
-                sessionResumeContentPrefix,
+                sessionResumeRecordContentPrefix,
                 sessionResumeToolFingerprint,
                 sessionResumeSubagentFingerprint,
               );
@@ -1564,7 +1570,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
             warnIfResumeNotCaptured(
               sessionResumeKey,
               sessionResumeKeyHash,
-              sessionResumeContentPrefix,
+              sessionResumeRecordContentPrefix,
               sessionResumeToolFingerprint,
               sessionResumeSubagentFingerprint,
               model,
@@ -1699,6 +1705,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
         sessionKey: sessionResumeKey,
         usedIncremental,
         contentPrefix: sessionResumeContentPrefix,
+        recordContentPrefix: sessionResumeRecordContentPrefix,
         toolFingerprint: sessionResumeToolFingerprint,
         subagentFingerprint: sessionResumeSubagentFingerprint,
       } = resolvePromptForBackend({
@@ -1773,14 +1780,14 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
             sessionResumeKey,
             model,
             workspaceDirectory,
-            sessionResumeContentPrefix,
+            sessionResumeRecordContentPrefix,
             sessionResumeToolFingerprint,
             sessionResumeSubagentFingerprint,
           );
           warnIfResumeNotCaptured(
             sessionResumeKey,
             sessionResumeKeyHashNode,
-            sessionResumeContentPrefix,
+            sessionResumeRecordContentPrefix,
             sessionResumeToolFingerprint,
             sessionResumeSubagentFingerprint,
             model,
@@ -1957,7 +1964,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
               sessionResumeKey,
               model,
               workspaceDirectory,
-              sessionResumeContentPrefix,
+              sessionResumeRecordContentPrefix,
               sessionResumeToolFingerprint,
               sessionResumeSubagentFingerprint,
             );
@@ -2065,7 +2072,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
               warnIfResumeNotCaptured(
                 sessionResumeKey,
                 sessionResumeKeyHashNode,
-                sessionResumeContentPrefix,
+                sessionResumeRecordContentPrefix,
                 sessionResumeToolFingerprint,
                 sessionResumeSubagentFingerprint,
                 model,

--- a/src/proxy/session-resume.ts
+++ b/src/proxy/session-resume.ts
@@ -83,6 +83,49 @@ export function deriveConversationAnchor(
   return undefined;
 }
 
+/**
+ * Prefixes used to validate a resume cache entry as a conversation advances.
+ *
+ * The session key intentionally remains based on the first real user message so
+ * turn 2 can find the chat ID recorded after turn 1. The content prefix is the
+ * safety check: lookup uses the prior user-message sequence, while recording
+ * stores the current user-message sequence for the next request. If two chats
+ * share the same opener but diverge later, the mismatch drops resume instead of
+ * attaching to the wrong cursor-agent chat.
+ */
+export function deriveConversationResumePrefixes(
+  messages: Array<ProxyMessage>,
+): { lookupContentPrefix: string; recordContentPrefix: string } | undefined {
+  const users: Array<{ canonical: string; prefix: string; index: number }> = [];
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
+    if (message?.role !== "user") continue;
+    const text = extractTextContent(message.content).trim();
+    if (!text || isMetaUserMessage(text)) continue;
+    users.push({
+      canonical: canonicalizeContentForAnchor(message.content),
+      prefix: text.slice(0, 500),
+      index,
+    });
+  }
+  if (users.length === 0) return undefined;
+
+  const lastUserIsLatestMessage = users[users.length - 1]?.index === messages.length - 1;
+  const lookupUsers = lastUserIsLatestMessage && users.length > 1
+    ? users.slice(0, -1)
+    : users;
+
+  return {
+    lookupContentPrefix: buildUserSequencePrefix(lookupUsers),
+    recordContentPrefix: buildUserSequencePrefix(users),
+  };
+}
+
+function buildUserSequencePrefix(users: Array<{ canonical: string; prefix: string }>): string {
+  if (users.length === 1) return users[0].prefix;
+  return `users:${users.length}:${simpleHash(users.map((user) => user.canonical).join("\n\0\n"))}`;
+}
+
 /** Canonical serialization of message content for anchor hashing.
  *  Includes text and non-text parts so identical text with different images
  *  do not collide. A pure-text array produces the same canonical form as a
@@ -144,15 +187,11 @@ export function getResumeChatId(
     return undefined;
   }
   if (expectedPrefix != null && entry.contentPrefix !== expectedPrefix) {
-    evictEntry(
-      sessionKey,
-      "contentPrefixMismatch",
-      {
-        storedPrefixLength: entry.contentPrefix.length,
-        expectedPrefixLength: expectedPrefix.length,
-      },
-      "warn",
-    );
+    log.warn("Skipping session resume entry due to content prefix mismatch", {
+      sessionKeyHash: sanitizeSessionKey(sessionKey),
+      storedPrefixLength: entry.contentPrefix.length,
+      expectedPrefixLength: expectedPrefix.length,
+    });
     return undefined;
   }
   if ((toolFingerprint || entry.toolFingerprint) && entry.toolFingerprint !== toolFingerprint) {

--- a/tests/unit/proxy/plugin-resume.test.ts
+++ b/tests/unit/proxy/plugin-resume.test.ts
@@ -93,6 +93,63 @@ describe("plugin resume orchestration", () => {
     expect(followUp.usedIncremental).toBe(true);
   });
 
+  it("does not reuse a resume chat across diverged same-opening conversations", () => {
+    process.env.CURSOR_ACP_SESSION_RESUME = "1";
+    const firstTurn = resolvePromptForBackend(baseInput);
+    captureResumeChatIdFromEvent(
+      { type: "system", session_id: "chat-abc" } as any,
+      firstTurn.sessionKey,
+      "gpt-5",
+      "/workspace",
+      firstTurn.contentPrefix,
+    );
+
+    const branchA = resolvePromptForBackend({
+      ...baseInput,
+      messages: [
+        { role: "user", content: "Remember BETA" },
+        { role: "assistant", content: "Got it." },
+        { role: "user", content: "What was the codeword?" },
+      ],
+    });
+    expect(branchA.resumeChatId).toBe("chat-abc");
+    expect(branchA.recordContentPrefix).toBeString();
+    expect(branchA.recordContentPrefix).not.toBe(branchA.contentPrefix);
+    captureResumeChatIdFromEvent(
+      { type: "result", session_id: "chat-abc" } as any,
+      branchA.sessionKey,
+      "gpt-5",
+      "/workspace",
+      branchA.recordContentPrefix,
+    );
+
+    const branchB = resolvePromptForBackend({
+      ...baseInput,
+      messages: [
+        { role: "user", content: "Remember BETA" },
+        { role: "assistant", content: "Got it." },
+        { role: "user", content: "Summarize the repo instead" },
+      ],
+    });
+
+    expect(branchB.resumeChatId).toBeUndefined();
+    expect(branchB.usedIncremental).toBe(false);
+
+    const branchANext = resolvePromptForBackend({
+      ...baseInput,
+      messages: [
+        { role: "user", content: "Remember BETA" },
+        { role: "assistant", content: "Got it." },
+        { role: "user", content: "What was the codeword?" },
+        { role: "assistant", content: "BETA." },
+        { role: "user", content: "Write it lowercase" },
+      ],
+    });
+
+    expect(branchANext.resumeChatId).toBe("chat-abc");
+    expect(branchANext.usedIncremental).toBe(true);
+  });
+
   it("resolvePromptForBackend: enabled + chatId + incremental null → full prompt + resume", () => {
     process.env.CURSOR_ACP_SESSION_RESUME = "1";
     const { sessionKey, contentPrefix } = resolvePromptForBackend(baseInput);

--- a/tests/unit/proxy/session-resume.test.ts
+++ b/tests/unit/proxy/session-resume.test.ts
@@ -229,11 +229,11 @@ describe("session-resume", () => {
     }
   });
 
-  it("treats prefix mismatch as a cache miss and evicts the stale entry", () => {
+  it("treats prefix mismatch as a cache miss without evicting another branch", () => {
     const key = buildSessionKey("/workspace", "gpt-5", "abc123");
     recordResumeChatId(key, "chat-uuid-1", "hello");
     expect(getResumeChatId(key, "different")).toBeUndefined();
-    expect(getResumeChatId(key)).toBeUndefined();
+    expect(getResumeChatId(key, "hello")).toBe("chat-uuid-1");
   });
 
   it("evicts entry on tool fingerprint mismatch", () => {


### PR DESCRIPTION
Tightens opt-in session resume so chats with the same opener but diverging follow-up messages do not attach to the wrong cursor-agent chat.

The session key still uses the first real user message so turn 2 can find the chat id recorded after turn 1. The cache validation prefix now evolves by user-message sequence:
- lookup uses the prior user-message sequence
- recording stores the current user-message sequence for the next request
- prefix mismatch is a non-evicting miss, so one divergent branch does not destroy another valid branch

Test plan:
- npm test -- tests/unit/proxy/session-resume.test.ts
- npm test -- tests/unit/proxy/plugin-resume.test.ts
- npm run build
- npm test