### PR TITLE
fix: suppress quota banner after successful stream

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -462,6 +462,20 @@ export function maybeEvictResumeChatId(
   return true;
 }
 
+function isSuccessfulResultEvent(event: StreamJsonEvent): boolean {
+  return isResult(event) && event.is_error !== true && event.subtype !== "error";
+}
+
+function shouldTreatCursorAgentFailureAsDiagnostic(
+  errSource: string,
+  sawSuccessfulStreamOutput: boolean,
+): boolean {
+  if (!sawSuccessfulStreamOutput) {
+    return false;
+  }
+  return parseAgentError(errSource).type === "quota";
+}
+
 /**
  * Warn once per request when session resume is enabled but cursor-agent did
  * not emit a usable `session_id`. Keeps the warning logic in one place across
@@ -1337,6 +1351,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
         async start(controller) {
           let streamTerminated = false;
           let firstTokenReceived = false;
+          let sawSuccessfulStreamOutput = false;
           let usage: OpenAiUsage | undefined;
           try {
             const reader = (child.stdout as ReadableStream<Uint8Array>).getReader();
@@ -1403,6 +1418,9 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
                 if (isResult(event)) {
                   usage = extractOpenAiUsageFromResult(event) ?? usage;
+                  if (isSuccessfulResultEvent(event)) {
+                    sawSuccessfulStreamOutput = true;
+                  }
                 }
 
                 if (event.type === "tool_call") {
@@ -1456,7 +1474,11 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
                   }
                 }
 
-                for (const sse of converter.handleEvent(event)) {
+                const sseChunks = converter.handleEvent(event);
+                if (sseChunks.length > 0 && (isAssistantText(event) || isThinking(event))) {
+                  sawSuccessfulStreamOutput = true;
+                }
+                for (const sse of sseChunks) {
                   controller.enqueue(encoder.encode(sse));
                 }
               }
@@ -1482,6 +1504,9 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
               );
               if (isResult(event)) {
                 usage = extractOpenAiUsageFromResult(event) ?? usage;
+                if (isSuccessfulResultEvent(event)) {
+                  sawSuccessfulStreamOutput = true;
+                }
               }
               if (event.type === "tool_call") {
                 const result = await handleToolLoopEventWithFallback({
@@ -1531,7 +1556,11 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
                   continue;
                 }
               }
-              for (const sse of converter.handleEvent(event)) {
+              const sseChunks = converter.handleEvent(event);
+              if (sseChunks.length > 0 && (isAssistantText(event) || isThinking(event))) {
+                sawSuccessfulStreamOutput = true;
+              }
+              for (const sse of sseChunks) {
                 controller.enqueue(encoder.encode(sse));
               }
             }
@@ -1544,24 +1573,31 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
               const stderrText = await new Response(child.stderr).text();
               const errSource = (stderrText || "").trim()
                 || `cursor-agent exited with code ${String(exitCode ?? "unknown")} and no output`;
-              // Only evict the cached chat ID when the failure indicates the resumed
-              // session itself is gone. Transient errors (network/auth/OOM/signals)
-              // should not discard a valid resume ID.
-              maybeEvictResumeChatId(errSource, resumeChatId, sessionResumeKey, {
-                code: exitCode,
-                failureTextHash: hashForLog(errSource),
-              });
-              const parsed = parseAgentError(errSource);
-              const msg = formatErrorForUser(parsed);
-              log.error("cursor-cli streaming failed", {
-                type: parsed.type,
-                code: exitCode,
-                failureTextHash: hashForLog(parsed.message),
-              });
-              const errChunk = createChatCompletionChunk(id, created, model, msg, true);
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
-              controller.enqueue(encoder.encode(formatSseDone()));
-              return;
+              if (shouldTreatCursorAgentFailureAsDiagnostic(errSource, sawSuccessfulStreamOutput)) {
+                log.warn("cursor-agent exited non-zero after successful streamed output; treating quota text as diagnostic", {
+                  code: exitCode,
+                  failureTextHash: hashForLog(errSource),
+                });
+              } else {
+                // Only evict the cached chat ID when the failure indicates the resumed
+                // session itself is gone. Transient errors (network/auth/OOM/signals)
+                // should not discard a valid resume ID.
+                maybeEvictResumeChatId(errSource, resumeChatId, sessionResumeKey, {
+                  code: exitCode,
+                  failureTextHash: hashForLog(errSource),
+                });
+                const parsed = parseAgentError(errSource);
+                const msg = formatErrorForUser(parsed);
+                log.error("cursor-cli streaming failed", {
+                  type: parsed.type,
+                  code: exitCode,
+                  failureTextHash: hashForLog(parsed.message),
+                });
+                const errChunk = createChatCompletionChunk(id, created, model, msg, true);
+                controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
+                controller.enqueue(encoder.encode(formatSseDone()));
+                return;
+              }
             }
 
             log.debug("cursor-agent completed (bun stream)", {
@@ -1889,6 +1925,7 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
         const stderrChunks: Buffer[] = [];
         let streamTerminated = false;
         let firstTokenReceived = false;
+        let sawSuccessfulStreamOutput = false;
         let usage: OpenAiUsage | undefined;
         child.stderr.on("data", (chunk) => {
           stderrChunks.push(Buffer.from(chunk));
@@ -1971,6 +2008,9 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
 
             if (isResult(event)) {
               usage = extractOpenAiUsageFromResult(event) ?? usage;
+              if (isSuccessfulResultEvent(event)) {
+                sawSuccessfulStreamOutput = true;
+              }
             }
 
             if (event.type === "tool_call") {
@@ -2019,7 +2059,11 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
             }
 
             if (streamTerminated || res.writableEnded) break;
-            for (const sse of converter.handleEvent(event)) {
+            const sseChunks = converter.handleEvent(event);
+            if (sseChunks.length > 0 && (isAssistantText(event) || isThinking(event))) {
+              sawSuccessfulStreamOutput = true;
+            }
+            for (const sse of sseChunks) {
               res.write(sse);
             }
           }
@@ -2052,21 +2096,28 @@ async function ensureCursorProxyServer(workspaceDirectory: string, toolRouter?: 
                 const errSource =
                   stderrText
                   || `cursor-agent exited with code ${String(childExitCode ?? "unknown")} and no output`;
-                // Only evict the cached chat ID when the failure indicates the resumed
-                // session itself is gone. Transient errors (network/auth/OOM/signals)
-                // should not discard a valid resume ID.
-                maybeEvictResumeChatId(errSource, resumeChatId, sessionResumeKey, {
-                  code: childExitCode,
-                  failureTextHash: hashForLog(errSource),
-                });
-                const parsed = parseAgentError(errSource);
-                const msg = formatErrorForUser(parsed);
-                const errChunk = createChatCompletionChunk(id, created, model, msg, true);
-                res.write(`data: ${JSON.stringify(errChunk)}\n\n`);
-                res.write(formatSseDone());
-                streamTerminated = true;
-                res.end();
-                return;
+                if (shouldTreatCursorAgentFailureAsDiagnostic(errSource, sawSuccessfulStreamOutput)) {
+                  log.warn("cursor-agent exited non-zero after successful streamed output; treating quota text as diagnostic", {
+                    code: childExitCode,
+                    failureTextHash: hashForLog(errSource),
+                  });
+                } else {
+                  // Only evict the cached chat ID when the failure indicates the resumed
+                  // session itself is gone. Transient errors (network/auth/OOM/signals)
+                  // should not discard a valid resume ID.
+                  maybeEvictResumeChatId(errSource, resumeChatId, sessionResumeKey, {
+                    code: childExitCode,
+                    failureTextHash: hashForLog(errSource),
+                  });
+                  const parsed = parseAgentError(errSource);
+                  const msg = formatErrorForUser(parsed);
+                  const errChunk = createChatCompletionChunk(id, created, model, msg, true);
+                  res.write(`data: ${JSON.stringify(errChunk)}\n\n`);
+                  res.write(formatSseDone());
+                  streamTerminated = true;
+                  res.end();
+                  return;
+                }
               }
 
               warnIfResumeNotCaptured(

--- a/tests/integration/opencode-loop.integration.test.ts
+++ b/tests/integration/opencode-loop.integration.test.ts
@@ -219,7 +219,8 @@ process.stdin.on("end", () => {
 
   if (scenario === "assistant-text-quota-exit") {
     process.stderr.write("You've hit your Cursor usage limit\\n");
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 });
 `;

--- a/tests/integration/opencode-loop.integration.test.ts
+++ b/tests/integration/opencode-loop.integration.test.ts
@@ -216,6 +216,11 @@ process.stdin.on("end", () => {
   for (const event of events) {
     process.stdout.write(JSON.stringify(event) + "\\n");
   }
+
+  if (scenario === "assistant-text-quota-exit") {
+    process.stderr.write("You've hit your Cursor usage limit\\n");
+    process.exit(1);
+  }
 });
 `;
 
@@ -585,6 +590,31 @@ describe("OpenCode-owned tool loop integration", () => {
 
     const promptText = readFileSync(promptFile, "utf8");
     expect(promptText).toContain("TOOL_RESULT (call_id: c1): {\"content\":\"file contents here\"}");
+  });
+
+  it("does not append quota error after successful streamed output", async () => {
+    process.env.MOCK_CURSOR_SCENARIO = "assistant-text-quota-exit";
+    process.env.MOCK_CURSOR_PROMPT_FILE = "";
+
+    const response = await requestCompletion(baseURL, {
+      model: "auto",
+      stream: true,
+      messages: [{ role: "user", content: "Say hello" }],
+    });
+
+    const body = await response.text();
+    const dataLines = parseSseData(body);
+    const chunks = parseJsonChunks(dataLines);
+
+    const allContent = chunks
+      .map((chunk) => chunk.choices?.[0]?.delta?.content)
+      .filter((value): value is string => typeof value === "string")
+      .join("");
+
+    expect(allContent).toContain("The file contains...");
+    expect(allContent).not.toContain("cursor-acp error");
+    expect(allContent).not.toContain("Cursor usage limit");
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
   });
 
   it("normalizes provider-prefixed model ids before invoking cursor-agent", async () => {


### PR DESCRIPTION
Small fix for the false quota banner we saw with Composer 2.5 Fast.

What changed:
- track whether streaming has already produced useful assistant output or a successful result
- if cursor-agent exits non-zero with quota text after that, log it as diagnostic instead of appending a second assistant error chunk
- keep the existing hard-error path when no successful streamed output was seen
- add an integration regression where the mock streams an answer, writes quota text to stderr, and exits 1

Test plan:
- npm test -- tests/integration/opencode-loop.integration.test.ts
- npm test -- tests/unit/errors.test.ts tests/unit/streaming/openai-sse.test.ts
- npm run verify:issue-92
- npm test