### PR TITLE
feat: show runtime settings in status

### DIFF
--- a/src/cli/opencode-cursor.ts
+++ b/src/cli/opencode-cursor.ts
@@ -22,8 +22,10 @@ import {
 import { resolveCursorAgentBinary } from "../utils/binary.js";
 import { getPossibleAuthPaths, isUsableSdkApiKey } from "../auth.js";
 import { parseCursorBackendPreference } from "../provider/backend.js";
+import { isAgentPoolEnabled, parseAgentPoolIdleMs } from "../client/cursor-agent-child.js";
 import { groupCursorModels, mergeCursorModelEntries } from "../models/variants.js";
 import { resolveOpenCodeConfigPath } from "../plugin-toggle.js";
+import { isSessionResumeEnabled } from "../proxy/session-resume.js";
 import type { DiscoveredModel } from "./model-discovery.js";
 
 const BRANDING_HEADER = `
@@ -64,6 +66,23 @@ type StatusResult = {
     legacyCursorAuthFile: boolean;
     sdkApiKey: boolean;
     sdkApiKeySource?: "CURSOR_API_KEY" | "provider.options.apiKey";
+  };
+  runtime: {
+    backend: {
+      preference: "auto" | "cursor-agent" | "sdk";
+    };
+    agentPool: {
+      enabled: boolean;
+      idleMs: number;
+    };
+    sessionResume: {
+      enabled: boolean;
+    };
+    logging: {
+      level: string;
+      console: boolean;
+      dir: string;
+    };
   };
 };
 
@@ -142,6 +161,26 @@ function resolveCliSdkAuthSource(config: unknown): StatusResult["auth"]["sdkApiK
     return "provider.options.apiKey";
   }
   return undefined;
+}
+
+function getRuntimeStatus(): StatusResult["runtime"] {
+  return {
+    backend: {
+      preference: parseCursorBackendPreference(process.env.CURSOR_ACP_BACKEND).preference,
+    },
+    agentPool: {
+      enabled: isAgentPoolEnabled(),
+      idleMs: parseAgentPoolIdleMs(),
+    },
+    sessionResume: {
+      enabled: isSessionResumeEnabled(),
+    },
+    logging: {
+      level: process.env.CURSOR_ACP_LOG_LEVEL || "info",
+      console: process.env.CURSOR_ACP_LOG_CONSOLE === "1",
+      dir: process.env.CURSOR_ACP_LOG_DIR || join(homedir(), ".opencode-cursor"),
+    },
+  };
 }
 
 function checkSdkApiKey(config: unknown): CheckResult {
@@ -895,6 +934,7 @@ export function getStatusResult(configPath: string, pluginPath: string): StatusR
       sdkApiKey: sdkApiKeySource !== undefined,
       sdkApiKeySource,
     },
+    runtime: getRuntimeStatus(),
   };
 }
 
@@ -1046,6 +1086,16 @@ function commandStatus(options: Options) {
   console.log(
     `  Cursor SDK API key: ${result.auth.sdkApiKey ? `found via ${result.auth.sdkApiKeySource}` : "not configured"}`,
   );
+
+  console.log("");
+  console.log("Runtime");
+  console.log(`  Backend preference: ${result.runtime.backend.preference}`);
+  console.log(`  Agent pool: ${result.runtime.agentPool.enabled ? "enabled" : "disabled"}`);
+  console.log(`  Agent pool idle: ${result.runtime.agentPool.idleMs}ms`);
+  console.log(`  Session resume: ${result.runtime.sessionResume.enabled ? "enabled" : "disabled"}`);
+  console.log(`  Log level: ${result.runtime.logging.level}`);
+  console.log(`  Console logging: ${result.runtime.logging.console ? "enabled" : "disabled"}`);
+  console.log(`  Log dir: ${result.runtime.logging.dir}`);
 }
 
 function commandDoctor(options: Options) {

--- a/tests/unit/cli/opencode-cursor.test.ts
+++ b/tests/unit/cli/opencode-cursor.test.ts
@@ -127,6 +127,73 @@ describe("cli/opencode-cursor status", () => {
     expect(result).toHaveProperty("provider");
     expect(result).toHaveProperty("aiSdk");
   });
+
+  it("reports the resolved default log directory", () => {
+    const originalLogDir = process.env.CURSOR_ACP_LOG_DIR;
+    delete process.env.CURSOR_ACP_LOG_DIR;
+
+    try {
+      const result = getStatusResult("/tmp/test-config.json", "/tmp/test-plugin");
+
+      expect(result.runtime.logging.dir).toBe(join(homedir(), ".opencode-cursor"));
+    } finally {
+      if (originalLogDir === undefined) {
+        delete process.env.CURSOR_ACP_LOG_DIR;
+      } else {
+        process.env.CURSOR_ACP_LOG_DIR = originalLogDir;
+      }
+    }
+  });
+
+  it("reports runtime settings that affect request performance", () => {
+    const originalEnv = {
+      CURSOR_ACP_AGENT_POOL: process.env.CURSOR_ACP_AGENT_POOL,
+      CURSOR_ACP_AGENT_POOL_IDLE_MS: process.env.CURSOR_ACP_AGENT_POOL_IDLE_MS,
+      CURSOR_ACP_SESSION_RESUME: process.env.CURSOR_ACP_SESSION_RESUME,
+      CURSOR_ACP_BACKEND: process.env.CURSOR_ACP_BACKEND,
+      CURSOR_ACP_LOG_LEVEL: process.env.CURSOR_ACP_LOG_LEVEL,
+      CURSOR_ACP_LOG_CONSOLE: process.env.CURSOR_ACP_LOG_CONSOLE,
+      CURSOR_ACP_LOG_DIR: process.env.CURSOR_ACP_LOG_DIR,
+    };
+
+    process.env.CURSOR_ACP_AGENT_POOL = "1";
+    process.env.CURSOR_ACP_AGENT_POOL_IDLE_MS = "0";
+    process.env.CURSOR_ACP_SESSION_RESUME = "yes";
+    process.env.CURSOR_ACP_BACKEND = "sdk";
+    process.env.CURSOR_ACP_LOG_LEVEL = "debug";
+    process.env.CURSOR_ACP_LOG_CONSOLE = "1";
+    process.env.CURSOR_ACP_LOG_DIR = "/tmp/open-cursor-logs";
+
+    try {
+      const result = getStatusResult("/tmp/test-config.json", "/tmp/test-plugin");
+
+      expect(result.runtime).toEqual({
+        backend: {
+          preference: "sdk",
+        },
+        agentPool: {
+          enabled: true,
+          idleMs: 0,
+        },
+        sessionResume: {
+          enabled: true,
+        },
+        logging: {
+          level: "debug",
+          console: true,
+          dir: "/tmp/open-cursor-logs",
+        },
+      });
+    } finally {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
 });
 
 describe("cli/opencode-cursor path resolution", () => {


### PR DESCRIPTION
PR A for the perf work.\n\nAdds a runtime block to open-cursor status / status --json so we can see the backend preference, agent pool, session resume, and logging settings before benchmarking.\n\nVerification:\n- bun test tests/unit/cli/opencode-cursor.test.ts\n- npm run build\n- npm test