### PR TITLE
fix: scope system transform to cursor models

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2778,6 +2778,13 @@ export const CursorPlugin: Plugin = async ({ $, directory, worktree, client, ser
 
     async "experimental.chat.system.transform"(input: any, output: { system: string[] }) {
       if (!toolsEnabled) return;
+      const boundaryContext = createBoundaryRuntimeContext("experimental.chat.system.transform");
+      const providerMatch = boundaryContext.run("matchesProvider", (boundary) =>
+        boundary.matchesProvider(input.model),
+      );
+      if (!providerMatch) {
+        return;
+      }
       const subagentNames = readSubagentNames();
       const systemMessage = buildAvailableToolsSystemMessage(
         lastToolNames, lastToolMap, mcpToolDefs, mcpToolSummaries,

--- a/tests/unit/plugin-system-transform-provider.test.ts
+++ b/tests/unit/plugin-system-transform-provider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { CursorPlugin } from "../../src/plugin";
+import type { PluginInput } from "@opencode-ai/plugin";
+
+function createMockInput(directory: string, worktree: string = directory): PluginInput {
+  return {
+    directory,
+    worktree,
+    serverUrl: new URL("http://localhost:8080"),
+    client: {
+      tool: {
+        list: async () => [],
+      },
+    } as any,
+    project: {} as any,
+    $: {} as any,
+  };
+}
+
+describe("experimental.chat.system.transform", () => {
+  it("injects system guidance for cursor-acp models", async () => {
+    const hooks = await CursorPlugin(createMockInput("/tmp/opencode-cursor-test"));
+    const transform = hooks["experimental.chat.system.transform"] as any;
+    const output: { system?: string[] } = {};
+
+    await transform({ model: { providerID: "cursor-acp" } }, output);
+
+    expect(output.system).toBeArray();
+    expect(output.system?.length).toBeGreaterThan(0);
+  });
+
+  it("does not inject system guidance for non-cursor providers", async () => {
+    const hooks = await CursorPlugin(createMockInput("/tmp/opencode-cursor-test"));
+    const transform = hooks["experimental.chat.system.transform"] as any;
+    const output: { system?: string[] } = {};
+
+    await transform({ model: { providerID: "sglang" } }, output);
+
+    expect(output.system).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add the same provider guard used by `chat.params` to `experimental.chat.system.transform`
- prevent `cursor-acp` from appending an extra system message for non-Cursor providers like `sglang`
- add a unit test covering Cursor vs non-Cursor provider behavior

## Testing
- Not run locally: `bun` is not installed in this environment