### PR TITLE
Fix duplicate write handling in opencode mode

### DIFF
--- a/docs/architecture/runtime-tool-loop.md
+++ b/docs/architecture/runtime-tool-loop.md
@@ -86,6 +86,10 @@ The OpenCode plugin tool hook (`buildToolHookEntries` in `src/plugin.ts`) regist
 
 When tool-hook execution is used, path/cwd defaults are normalized against tool context (`worktree` / `directory`) to keep file and shell behavior workspace-aware.
 
+In default `opencode` mode, OpenCode owns the native `write` tool. The plugin does not register its own native-name `write` hook in that mode, because duplicate native `write` handling can turn a successful OpenCode write into a plugin guard error. The plugin still exposes `oc_write` for compatibility paths and direct local-tool execution.
+
+When debugging tool loops, isolate the failing boundary before changing behavior: the model may emit a malformed tool call, `cursor-agent` may transport an unexpected shape, the plugin may normalize or intercept it incorrectly, or OpenCode may execute/report it differently than the model expects. For post-tool stalls, first verify that a second turn containing the prior `role: "tool"` result can reach a normal assistant `stop`.
+
 ## Usage Metrics
 
 `cursor-agent --output-format stream-json` emits a final `result` event with token usage when Cursor reports it. The proxy maps that payload to OpenAI-compatible usage so OpenCode can emit `step-finish` token data for tools such as OpenCode TokenSpeed Monitor.

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -66,7 +66,7 @@ import { LocalExecutor } from "./tools/executors/local.js";
 import { SdkExecutor } from "./tools/executors/sdk.js";
 import { McpExecutor } from "./tools/executors/mcp.js";
 import { executeWithChain } from "./tools/core/executor.js";
-import { registerDefaultTools } from "./tools/defaults.js";
+import { WRITE_TOOL_TARGETED_EDIT_CONTRACT, registerDefaultTools } from "./tools/defaults.js";
 import type { IToolExecutor } from "./tools/core/types.js";
 import {
   createProviderBoundary,
@@ -817,13 +817,63 @@ const {
   FORWARD_TOOL_CALLS,
   EMIT_TOOL_UPDATES,
 );
-
 export function resolveChatParamTools(
   mode: ToolLoopMode,
   existingTools: unknown,
   refreshedTools: Array<any>,
 ): ToolOptionResolution {
   return PROVIDER_BOUNDARY.resolveChatParamTools(mode, existingTools, refreshedTools);
+}
+
+export function applyCursorWriteToolContract(tools: unknown): unknown {
+  if (!Array.isArray(tools)) {
+    return tools;
+  }
+
+  let changed = false;
+  const patched = tools.map((tool) => {
+    if (!tool || typeof tool !== "object") {
+      return tool;
+    }
+
+    const record = tool as Record<string, any>;
+    const functionRecord = record.function;
+    const isFunctionWrite =
+      functionRecord && typeof functionRecord === "object" && functionRecord.name === "write";
+    const isTopLevelWrite = record.name === "write";
+
+    if (!isFunctionWrite && !isTopLevelWrite) {
+      return tool;
+    }
+
+    const target = isFunctionWrite ? functionRecord : record;
+    const description = typeof target.description === "string" ? target.description : "";
+    if (description.includes(WRITE_TOOL_TARGETED_EDIT_CONTRACT)) {
+      return tool;
+    }
+
+    changed = true;
+    const nextDescription = description
+      ? `${description.trim()} ${WRITE_TOOL_TARGETED_EDIT_CONTRACT}`
+      : WRITE_TOOL_TARGETED_EDIT_CONTRACT;
+
+    if (isFunctionWrite) {
+      return {
+        ...record,
+        function: {
+          ...functionRecord,
+          description: nextDescription,
+        },
+      };
+    }
+
+    return {
+      ...record,
+      description: nextDescription,
+    };
+  });
+
+  return changed ? patched : tools;
 }
 
 function createChatCompletionResponse(
@@ -2431,14 +2481,20 @@ function applyToolContextDefaults(
 /**
  * Build tool hook entries from local registry
  */
-const NATIVE_TOOL_HOOK_EXCLUSIONS = new Set(["grep"]);
+const TOOL_HOOK_EXCLUSIONS = new Set(["grep"]);
+const OPENCODE_NATIVE_TOOL_HOOK_EXCLUSIONS = new Set(["write"]);
+
+// Exported for mode-boundary tests without initializing the full plugin runtime.
+export function shouldRegisterNativeToolHook(toolName: string, mode: ToolLoopMode): boolean {
+  return !(mode === "opencode" && OPENCODE_NATIVE_TOOL_HOOK_EXCLUSIONS.has(toolName));
+}
 
 function buildToolHookEntries(registry: CoreRegistry, fallbackBaseDir?: string): Record<string, any> {
   const entries: Record<string, any> = {};
   const sessionWorkspaceBySession = new Map<string, string>();
   const tools = registry.list();
   for (const t of tools) {
-    if (NATIVE_TOOL_HOOK_EXCLUSIONS.has(t.name)) continue;
+    if (TOOL_HOOK_EXCLUSIONS.has(t.name)) continue;
 
     const handler = registry.getHandler(t.name);
     if (!handler) continue;
@@ -2465,7 +2521,9 @@ function buildToolHookEntries(registry: CoreRegistry, fallbackBaseDir?: string):
         },
       });
 
-    entries[t.name] = createEntry(t.name);
+    if (shouldRegisterNativeToolHook(t.name, TOOL_LOOP_MODE)) {
+      entries[t.name] = createEntry(t.name);
+    }
 
     const ocAlias = `oc_${t.id}`;
     if (!entries[ocAlias]) {
@@ -2747,9 +2805,10 @@ export const CursorPlugin: Plugin = async ({ $, directory, worktree, client, ser
           );
 
           if (resolved.action === "override" || resolved.action === "fallback") {
-            output.options.tools = resolved.tools;
+            output.options.tools = applyCursorWriteToolContract(resolved.tools);
           } else if (resolved.action === "preserve") {
             const count = Array.isArray(existingTools) ? existingTools.length : 0;
+            output.options.tools = applyCursorWriteToolContract(existingTools);
             log.debug("Using OpenCode-provided tools from chat.params", { count });
           }
         } catch (err) {

--- a/src/tools/defaults.ts
+++ b/src/tools/defaults.ts
@@ -1,6 +1,9 @@
 import type { ToolRegistry } from "./core/registry.js";
 import { createLogger } from "../utils/logger.js";
 
+export const WRITE_TOOL_TARGETED_EDIT_CONTRACT =
+  "Use only for new files or intentional full-file replacement. For targeted edits to existing files, use edit with old_string and new_string.";
+
 /**
  * Register default OpenCode tools in the registry
  */
@@ -124,7 +127,7 @@ export function registerDefaultTools(registry: ToolRegistry): void {
   registry.register({
     id: "write",
     name: "write",
-    description: "Write content to a file (creates or overwrites). Prefer this over using bash redirection/heredocs for file creation.",
+    description: `Write content to a file. ${WRITE_TOOL_TARGETED_EDIT_CONTRACT}`,
     parameters: {
       type: "object",
       properties: {
@@ -546,8 +549,9 @@ function writeFullFileWithOverwriteGuard(
       throw new Error(
         `${toolName}: refusing suspicious partial overwrite of existing file ${filePath} `
           + `(${suspicious.existingLines} lines -> ${suspicious.nextLines} lines). `
-          + "write/edit full-file replacement overwrites the whole file; use edit with old_string/new_string "
-          + "for targeted changes, or pass force: true only when intentionally replacing the full file.",
+          + `${WRITE_TOOL_TARGETED_EDIT_CONTRACT} `
+          + "Do not retry write for this targeted change; call edit with path, old_string, and new_string. "
+          + "Pass force: true only when intentionally replacing the full file.",
       );
     }
   }

--- a/tests/integration/opencode-loop.integration.test.ts
+++ b/tests/integration/opencode-loop.integration.test.ts
@@ -200,6 +200,17 @@ process.stdin.on("end", () => {
         },
       },
     ];
+  } else if (scenario === "assistant-done") {
+    events = [
+      {
+        type: "assistant",
+        timestamp_ms: now + 1,
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "DONE" }],
+        },
+      },
+    ];
   } else {
     events = [
       {
@@ -656,6 +667,56 @@ describe("OpenCode-owned tool loop integration", () => {
 
     const promptText = readFileSync(promptFile, "utf8");
     expect(promptText).toContain("TOOL_RESULT (call_id: c1): {\"content\":\"file contents here\"}");
+  });
+
+  it("continues after a successful write tool result and can stop with DONE", async () => {
+    process.env.MOCK_CURSOR_SCENARIO = "assistant-done";
+    process.env.MOCK_CURSOR_PROMPT_FILE = promptFile;
+
+    const response = await requestCompletion(baseURL, {
+      model: "auto",
+      stream: true,
+      tools: [WRITE_TOOL],
+      messages: [
+        { role: "user", content: "Change line 50 and reply DONE after saving" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "c-write-1",
+              type: "function",
+              function: {
+                name: "write",
+                arguments: "{\"path\":\"test.txt\",\"content\":\"updated\"}",
+              },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          tool_call_id: "c-write-1",
+          content: "Wrote file successfully.",
+        },
+      ],
+    });
+
+    const body = await response.text();
+    const dataLines = parseSseData(body);
+    const chunks = parseJsonChunks(dataLines);
+
+    const contentTexts = chunks
+      .map((chunk) => chunk.choices?.[0]?.delta?.content)
+      .filter((value): value is string => typeof value === "string");
+    expect(contentTexts.join("")).toContain("DONE");
+
+    const finishReasons = chunks.map((chunk) => chunk.choices?.[0]?.finish_reason).filter(Boolean);
+    expect(finishReasons).toContain("stop");
+    expect(finishReasons).not.toContain("tool_calls");
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
+
+    const promptText = readFileSync(promptFile, "utf8");
+    expect(promptText).toContain("TOOL_RESULT (call_id: c-write-1): Wrote file successfully.");
   });
 
   it("does not append quota error after successful streamed output", async () => {

--- a/tests/tools/defaults.test.ts
+++ b/tests/tools/defaults.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "bun:test";
 import { ToolRegistry } from "../../src/tools/core/registry.js";
-import { registerDefaultTools, getDefaultToolNames, resolveShellOption } from "../../src/tools/defaults.js";
+import {
+  WRITE_TOOL_TARGETED_EDIT_CONTRACT,
+  registerDefaultTools,
+  getDefaultToolNames,
+  resolveShellOption,
+} from "../../src/tools/defaults.js";
 import { executeWithChain } from "../../src/tools/core/executor.js";
 import { LocalExecutor } from "../../src/tools/executors/local.js";
 
@@ -48,6 +53,7 @@ describe("Default Tools", () => {
 
     const write = registry.getTool("write");
     expect(write?.name).toBe("write");
+    expect(write?.description).toContain(WRITE_TOOL_TARGETED_EDIT_CONTRACT);
 
     const edit = registry.getTool("edit");
     expect(edit?.name).toBe("edit");
@@ -172,6 +178,8 @@ describe("Default Tools", () => {
 
       expect(result.status).toBe("error");
       expect(result.error).toContain("refusing suspicious partial overwrite");
+      expect(result.error).toContain("Do not retry write for this targeted change");
+      expect(result.error).toContain("call edit with path, old_string, and new_string");
       expect(fs.readFileSync(tmpFile, "utf-8")).toBe(original);
     } finally {
       fs.unlinkSync(tmpFile);

--- a/tests/unit/plugin-tool-resolution.test.ts
+++ b/tests/unit/plugin-tool-resolution.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { resolveChatParamTools } from "../../src/plugin";
+import { applyCursorWriteToolContract, resolveChatParamTools } from "../../src/plugin";
 
 describe("resolveChatParamTools", () => {
   it("preserves existing tools in opencode mode", () => {
@@ -33,5 +33,79 @@ describe("resolveChatParamTools", () => {
 
     expect(resolved.action).toBe("none");
     expect(resolved.tools).toBe(existing);
+  });
+});
+
+describe("applyCursorWriteToolContract", () => {
+  it("adds the cursor write contract to preserved OpenCode write tools without mutating input", () => {
+    const existing = [
+      {
+        type: "function",
+        function: {
+          name: "write",
+          description: "Write a file",
+        },
+      },
+      {
+        type: "function",
+        function: {
+          name: "read",
+          description: "Read a file",
+        },
+      },
+    ];
+
+    const patched = applyCursorWriteToolContract(existing) as typeof existing;
+
+    expect(patched).not.toBe(existing);
+    expect(patched[0]).not.toBe(existing[0]);
+    expect(patched[0].function).not.toBe(existing[0].function);
+    expect(patched[0].function.description).toContain(
+      "Use only for new files or intentional full-file replacement.",
+    );
+    expect(patched[0].function.description).toContain(
+      "For targeted edits to existing files, use edit with old_string and new_string.",
+    );
+    expect(patched[1]).toBe(existing[1]);
+    expect(existing[0].function.description).toBe("Write a file");
+  });
+
+  it("does not duplicate the cursor write contract", () => {
+    const existing = [
+      {
+        function: {
+          name: "write",
+          description:
+            "Write a file. Use only for new files or intentional full-file replacement. For targeted edits to existing files, use edit with old_string and new_string.",
+        },
+      },
+    ];
+
+    const patched = applyCursorWriteToolContract(existing) as typeof existing;
+
+    expect(patched[0].function.description).toBe(existing[0].function.description);
+  });
+
+  it("adds the cursor write contract to top-level write tool definitions", () => {
+    const existing = [
+      {
+        name: "write",
+        description: "Write a file",
+      },
+    ];
+
+    const patched = applyCursorWriteToolContract(existing) as typeof existing;
+
+    expect(patched).not.toBe(existing);
+    expect(patched[0]).not.toBe(existing[0]);
+    expect(patched[0].description).toContain(
+      "Use only for new files or intentional full-file replacement.",
+    );
+  });
+
+  it("leaves non-array tool payloads unchanged", () => {
+    const existing = { function: { name: "write" } };
+
+    expect(applyCursorWriteToolContract(existing)).toBe(existing);
   });
 });

--- a/tests/unit/plugin-tools-hook.test.ts
+++ b/tests/unit/plugin-tools-hook.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { mkdtempSync, readFileSync, realpathSync, rmSync, mkdirSync, existsSync, symlinkSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { CursorPlugin } from "../../src/plugin";
+import { CursorPlugin, shouldRegisterNativeToolHook } from "../../src/plugin";
 import type { PluginInput } from "@opencode-ai/plugin";
 
 function createMockInput(directory: string, worktree: string = directory): PluginInput {
@@ -47,22 +47,26 @@ describe("Plugin tool hook", () => {
     expect(hooks.tool).toBeDefined();
     expect(typeof hooks.tool).toBe("object");
 
-    // Verify default tools are registered
+    // Verify local aliases are registered without shadowing OpenCode native tools.
     const toolNames = Object.keys(hooks.tool || {});
     expect(toolNames).toContain("bash");
     expect(toolNames).toContain("shell");
     expect(toolNames).toContain("read");
-    expect(toolNames).toContain("write");
+    expect(toolNames).not.toContain("write");
     expect(toolNames).toContain("edit");
     expect(toolNames).toContain("oc_edit");
     expect(toolNames).toContain("oc_write");
     expect(toolNames).toContain("oc_read");
     expect(toolNames).not.toContain("grep");
+    expect(toolNames).not.toContain("oc_grep");
     expect(toolNames).toContain("ls");
     expect(toolNames).toContain("glob");
+    expect(toolNames).toContain("mkdir");
+    expect(toolNames).toContain("rm");
+    expect(toolNames).toContain("stat");
 
     // Verify tool structure (each should have description, args, execute)
-    const bashTool = hooks.tool?.bash;
+    const bashTool = hooks.tool?.oc_bash;
     expect(bashTool).toBeDefined();
     expect(bashTool?.description).toBeDefined();
     expect(bashTool?.args).toBeDefined();
@@ -75,11 +79,18 @@ describe("Plugin tool hook", () => {
     expect(typeof shellTool?.execute).toBe("function");
   });
 
-  it("resolves relative write paths against context directory", async () => {
+  it("registers native write only outside OpenCode-owned tool-loop mode", () => {
+    expect(shouldRegisterNativeToolHook("write", "opencode")).toBe(false);
+    expect(shouldRegisterNativeToolHook("write", "proxy-exec")).toBe(true);
+    expect(shouldRegisterNativeToolHook("write", "off")).toBe(true);
+    expect(shouldRegisterNativeToolHook("edit", "opencode")).toBe(true);
+  });
+
+  it("resolves relative oc_write paths against context directory", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-write-"));
     try {
       const hooks = await CursorPlugin(createMockInput(projectDir));
-      const out = await hooks.tool?.write?.execute(
+      const out = await hooks.tool?.oc_write?.execute(
         {
           path: "nested/output.txt",
           content: "hello from context",
@@ -93,7 +104,7 @@ describe("Plugin tool hook", () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("prefers worktree when context.directory is the OpenCode config dir", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-worktree-"));
@@ -105,7 +116,7 @@ describe("Plugin tool hook", () => {
       mkdirSync(configDir, { recursive: true });
 
       const hooks = await CursorPlugin(createMockInput(configDir, projectDir));
-      const out = await hooks.tool?.write?.execute(
+      const out = await hooks.tool?.oc_write?.execute(
         { path: "nested/output.txt", content: "hello from worktree" },
         createToolContext(configDir, projectDir),
       );
@@ -122,13 +133,13 @@ describe("Plugin tool hook", () => {
       rmSync(projectDir, { recursive: true, force: true });
       rmSync(xdgConfigHome, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
-  it("defaults bash cwd to context directory", async () => {
+  it("defaults oc_bash cwd to context directory", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-bash-"));
     try {
       const hooks = await CursorPlugin(createMockInput(projectDir));
-      const out = await hooks.tool?.bash?.execute(
+      const out = await hooks.tool?.oc_bash?.execute(
         {
           command: "pwd",
         },
@@ -156,7 +167,7 @@ describe("Plugin tool hook", () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("executes oc_bash alias and defaults cwd to context directory", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-oc-bash-"));
@@ -193,7 +204,7 @@ describe("Plugin tool hook", () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("rejects oc_edit with empty old_string without overwriting existing files", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-oc-edit-empty-old-"));
@@ -214,7 +225,7 @@ describe("Plugin tool hook", () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("rejects oc_write partial overwrites of existing files", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-oc-write-partial-"));
@@ -236,7 +247,7 @@ describe("Plugin tool hook", () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("rejects malformed edit full-file payloads that look like partial overwrites", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-edit-streamcontent-partial-"));
@@ -248,7 +259,7 @@ describe("Plugin tool hook", () => {
       writeFileSync(target, original, "utf-8");
 
       await expect(
-        hooks.tool?.edit?.execute(
+        hooks.tool?.oc_edit?.execute(
           { path: target, streamContent: "test test" },
           createToolContext(projectDir, projectDir),
         ),
@@ -258,7 +269,7 @@ describe("Plugin tool hook", () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("rejects normalized edit content payloads that look like partial overwrites", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-edit-content-partial-"));
@@ -270,7 +281,7 @@ describe("Plugin tool hook", () => {
       writeFileSync(target, original, "utf-8");
 
       await expect(
-        hooks.tool?.edit?.execute(
+        hooks.tool?.oc_edit?.execute(
           { path: target, content: "49\ntest test\n51" },
           createToolContext(projectDir, projectDir),
         ),
@@ -280,7 +291,7 @@ describe("Plugin tool hook", () => {
     } finally {
       rmSync(projectDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("pins non-config workspace per session and reuses it when later context loses worktree", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-session-pin-project-"));
@@ -295,11 +306,11 @@ describe("Plugin tool hook", () => {
 
       const hooks = await CursorPlugin(createMockInput(configDir, configDir));
 
-      const out1 = await hooks.tool?.write?.execute(
+      const out1 = await hooks.tool?.oc_write?.execute(
         { path: "nested/first.txt", content: "first" },
         createToolContext(configDir, projectDir, "session-pin-1"),
       );
-      const out2 = await hooks.tool?.write?.execute(
+      const out2 = await hooks.tool?.oc_write?.execute(
         { path: "nested/second.txt", content: "second" },
         createToolContext(configDir, undefined, "session-pin-1"),
       );
@@ -323,7 +334,7 @@ describe("Plugin tool hook", () => {
       rmSync(xdgConfigHome, { recursive: true, force: true });
       rmSync(unexpectedDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 
   it("treats config path aliases (symlink/case variants) as config and falls back to workspace", async () => {
     const projectDir = mkdtempSync(join(tmpdir(), "plugin-hook-config-alias-project-"));
@@ -343,7 +354,7 @@ describe("Plugin tool hook", () => {
       const filename = `symlink-alias-${Date.now()}.txt`;
 
       const hooks = await CursorPlugin(createMockInput(configDir, projectDir));
-      const out = await hooks.tool?.write?.execute(
+      const out = await hooks.tool?.oc_write?.execute(
         { path: `nested/${filename}`, content: "alias fallback" },
         createToolContext(aliasConfigDir, undefined, "session-alias-1"),
       );
@@ -364,5 +375,5 @@ describe("Plugin tool hook", () => {
       rmSync(xdgConfigHome, { recursive: true, force: true });
       rmSync(aliasParentDir, { recursive: true, force: true });
     }
-  });
+  }, 15000);
 });


### PR DESCRIPTION
## Summary
- Stop registering the native write hook in opencode tool-loop mode, so opencode owns native write execution.
- Keep oc_write available, and keep native write registration for proxy-exec and off modes.
- Add one shared write-tool contract that points targeted existing-file changes to edit.

## Notes
Issue #83 started around missing oc_* hooks. The current failure traced to duplicate native write handling after aliases existed: opencode completed write, then the plugin guard could return a partial-overwrite error and keep the model looping.

Manual Composer checks against the dev plugin did not reproduce the duplicate-write guard loop. Separate prompts stalled after read or produced malformed edit args; those need a separate patch if we can isolate a plugin-side cause.

Fixes #83

## Testing
- bun test tests/integration/opencode-loop.integration.test.ts tests/tools/defaults.test.ts tests/unit/plugin-tool-resolution.test.ts tests/unit/plugin-tools-hook.test.ts
- bun run test:ci:unit
- bun run build