### PR TITLE
fix: preserve repeated streaming tokens

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -8,15 +8,16 @@ import { homedir } from "os";
 import { isAbsolute, join, relative, resolve } from "path";
 import { ToolMapper, type ToolUpdate } from "./acp/tools.js";
 import { LineBuffer } from "./streaming/line-buffer.js";
-import { MixedDeltaTracker } from "./streaming/delta-tracker.js";
 import { StreamToSseConverter, formatSseDone } from "./streaming/openai-sse.js";
 import { parseStreamJsonLine } from "./streaming/parser.js";
 import {
   extractText,
   extractThinking,
   isAssistantText,
+  isPartialStreamDelta,
   isResult,
   isThinking,
+  isToolCall,
   type StreamJsonEvent,
 } from "./streaming/types.js";
 import {
@@ -994,12 +995,11 @@ export function extractCompletionFromStream(output: string): {
   usage?: OpenAiUsage;
 } {
   const lines = output.split("\n");
-  let assistantText = "";
-  let reasoningText = "";
+  let assistantPrefix = "";
+  let assistantSegment = "";
+  let reasoningPrefix = "";
+  let reasoningSegment = "";
   let usage: OpenAiUsage | undefined;
-  let sawAssistantPartials = false;
-  let sawThinkingPartials = false;
-  const tracker = new MixedDeltaTracker();
 
   for (const line of lines) {
     const event = parseStreamJsonLine(line);
@@ -1011,26 +1011,21 @@ export function extractCompletionFromStream(output: string): {
       const text = extractText(event);
       if (!text) continue;
 
-      const isPartial = typeof (event as any).timestamp_ms === "number";
-      if (isPartial) {
-        sawAssistantPartials = true;
-        assistantText += tracker.nextText(text);
-      } else if (!sawAssistantPartials) {
-        assistantText = text;
-      }
+      assistantSegment = isPartialStreamDelta(event) ? assistantSegment + text : text;
     }
 
     if (isThinking(event)) {
       const thinking = extractThinking(event);
       if (thinking) {
-        const isPartial = typeof (event as any).timestamp_ms === "number";
-        if (isPartial) {
-          sawThinkingPartials = true;
-          reasoningText += tracker.nextThinking(thinking);
-        } else if (!sawThinkingPartials) {
-          reasoningText = thinking;
-        }
+        reasoningSegment = isPartialStreamDelta(event) ? reasoningSegment + thinking : thinking;
       }
+    }
+
+    if (isToolCall(event) && event.subtype === "started") {
+      assistantPrefix += assistantSegment;
+      assistantSegment = "";
+      reasoningPrefix += reasoningSegment;
+      reasoningSegment = "";
     }
 
     if (isResult(event)) {
@@ -1038,7 +1033,11 @@ export function extractCompletionFromStream(output: string): {
     }
   }
 
-  return { assistantText, reasoningText, usage };
+  return {
+    assistantText: assistantPrefix + assistantSegment,
+    reasoningText: reasoningPrefix + reasoningSegment,
+    usage,
+  };
 }
 
 function formatToolUpdateEvent(update: ToolUpdate): string {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,7 +17,7 @@ import {
   isPartialStreamDelta,
   isResult,
   isThinking,
-  isToolCall,
+  isToolCallStart,
   type StreamJsonEvent,
 } from "./streaming/types.js";
 import {
@@ -1021,7 +1021,7 @@ export function extractCompletionFromStream(output: string): {
       }
     }
 
-    if (isToolCall(event) && event.subtype === "started") {
+    if (isToolCallStart(event)) {
       assistantPrefix += assistantSegment;
       assistantSegment = "";
       reasoningPrefix += reasoningSegment;

--- a/src/streaming/ai-sdk-parts.ts
+++ b/src/streaming/ai-sdk-parts.ts
@@ -3,6 +3,7 @@ import {
   extractThinking,
   inferToolName,
   isAssistantText,
+  isPartialStreamDelta,
   isThinking,
   isToolCall,
   type StreamJsonEvent,
@@ -42,18 +43,21 @@ export class StreamToAiSdkParts {
     if (isAssistantText(event)) {
       const text = extractText(event);
       if (!text) return [];
-      const delta = this.tracker.nextText(text);
+      const delta = this.tracker.nextText(text, isPartialStreamDelta(event));
       return delta ? [{ type: "text-delta", textDelta: delta }] : [];
     }
 
     if (isThinking(event)) {
       const text = extractThinking(event);
       if (!text) return [];
-      const delta = this.tracker.nextThinking(text);
+      const delta = this.tracker.nextThinking(text, isPartialStreamDelta(event));
       return delta ? [{ type: "text-delta", textDelta: delta }] : [];
     }
 
     if (isToolCall(event)) {
+      if (event.subtype === "started") {
+        this.tracker.reset();
+      }
       return this.handleToolCall(event);
     }
 

--- a/src/streaming/ai-sdk-parts.ts
+++ b/src/streaming/ai-sdk-parts.ts
@@ -6,6 +6,7 @@ import {
   isPartialStreamDelta,
   isThinking,
   isToolCall,
+  isToolCallStart,
   type StreamJsonEvent,
   type StreamJsonToolCallEvent,
 } from "./types.js";
@@ -55,7 +56,7 @@ export class StreamToAiSdkParts {
     }
 
     if (isToolCall(event)) {
-      if (event.subtype === "started") {
+      if (isToolCallStart(event)) {
         this.tracker.reset();
       }
       return this.handleToolCall(event);

--- a/src/streaming/delta-tracker.ts
+++ b/src/streaming/delta-tracker.ts
@@ -50,16 +50,16 @@ export class MixedDeltaTracker {
   private emittedText = "";
   private emittedThinking = "";
 
-  nextText(value: string): string {
-    const delta = this.diff(this.emittedText, value);
+  nextText(value: string, isDelta = false): string {
+    const delta = isDelta ? value : this.diff(this.emittedText, value);
     if (delta) {
       this.emittedText += delta;
     }
     return delta;
   }
 
-  nextThinking(value: string): string {
-    const delta = this.diff(this.emittedThinking, value);
+  nextThinking(value: string, isDelta = false): string {
+    const delta = isDelta ? value : this.diff(this.emittedThinking, value);
     if (delta) {
       this.emittedThinking += delta;
     }

--- a/src/streaming/openai-sse.ts
+++ b/src/streaming/openai-sse.ts
@@ -3,6 +3,7 @@ import {
   extractThinking,
   inferToolName,
   isAssistantText,
+  isPartialStreamDelta,
   isThinking,
   isToolCall,
   type StreamJsonEvent,
@@ -72,18 +73,21 @@ export class StreamToSseConverter {
     if (isAssistantText(event)) {
       const text = extractText(event);
       if (!text) return [];
-      const delta = this.tracker.nextText(text);
+      const delta = this.tracker.nextText(text, isPartialStreamDelta(event));
       return delta ? [this.chunkWith({ content: delta })] : [];
     }
 
     if (isThinking(event)) {
       const text = extractThinking(event);
       if (!text) return [];
-      const delta = this.tracker.nextThinking(text);
+      const delta = this.tracker.nextThinking(text, isPartialStreamDelta(event));
       return delta ? [this.chunkWith({ reasoning_content: delta })] : [];
     }
 
     if (isToolCall(event)) {
+      if (event.subtype === "started") {
+        this.tracker.reset();
+      }
       return [this.chunkWith(this.toolCallDelta(event))];
     }
 

--- a/src/streaming/openai-sse.ts
+++ b/src/streaming/openai-sse.ts
@@ -6,6 +6,7 @@ import {
   isPartialStreamDelta,
   isThinking,
   isToolCall,
+  isToolCallStart,
   type StreamJsonEvent,
   type StreamJsonToolCallEvent,
 } from "./types.js";
@@ -85,7 +86,7 @@ export class StreamToSseConverter {
     }
 
     if (isToolCall(event)) {
-      if (event.subtype === "started") {
+      if (isToolCallStart(event)) {
         this.tracker.reset();
       }
       return [this.chunkWith(this.toolCallDelta(event))];

--- a/src/streaming/types.ts
+++ b/src/streaming/types.ts
@@ -121,13 +121,16 @@ export const isThinking = (
 export const isPartialStreamDelta = (
   event: StreamJsonAssistantEvent | StreamJsonThinkingEvent,
 ) => {
-  // ponytail: Cursor currently marks timestamped snapshots with model_call_id;
-  // prefer an explicit delta/snapshot subtype if the protocol adds one.
+  // ponytail: Cursor marks timestamped snapshots with model_call_id even when
+  // subtype says delta; prefer a trustworthy protocol subtype if one is added.
   return typeof event.timestamp_ms === "number" && typeof event.model_call_id !== "string";
 };
 
 export const isToolCall = (event: StreamJsonEvent): event is StreamJsonToolCallEvent =>
   event.type === "tool_call";
+
+export const isToolCallStart = (event: StreamJsonEvent): event is StreamJsonToolCallEvent =>
+  isToolCall(event) && (event.subtype ?? "started") === "started";
 
 export const isResult = (event: StreamJsonEvent): event is StreamJsonResultEvent =>
   event.type === "result";

--- a/src/streaming/types.ts
+++ b/src/streaming/types.ts
@@ -36,6 +36,7 @@ export type StreamJsonAssistantEvent = {
   type: "assistant";
   timestamp?: number;
   timestamp_ms?: number;
+  model_call_id?: string;
   session_id?: string;
   message: {
     role: "assistant";
@@ -54,6 +55,7 @@ export type StreamJsonThinkingEvent = {
   text?: string;
   timestamp?: number;
   timestamp_ms?: number;
+  model_call_id?: string;
   session_id?: string;
 };
 
@@ -114,6 +116,14 @@ export const isThinking = (
   }
 
   return event.type === "assistant" && hasThinkingContent(event);
+};
+
+export const isPartialStreamDelta = (
+  event: StreamJsonAssistantEvent | StreamJsonThinkingEvent,
+) => {
+  // ponytail: Cursor currently marks timestamped snapshots with model_call_id;
+  // prefer an explicit delta/snapshot subtype if the protocol adds one.
+  return typeof event.timestamp_ms === "number" && typeof event.model_call_id !== "string";
 };
 
 export const isToolCall = (event: StreamJsonEvent): event is StreamJsonToolCallEvent =>

--- a/tests/unit/plugin-stream-extraction.test.ts
+++ b/tests/unit/plugin-stream-extraction.test.ts
@@ -61,7 +61,7 @@ describe("extractCompletionFromStream", () => {
     const output = [
       { type: "assistant", timestamp_ms: 1, message: { role: "assistant", content: [{ type: "text", text: "Reading" }] } },
       { type: "assistant", timestamp_ms: 2, model_call_id: "call-before-tool", message: { role: "assistant", content: [{ type: "text", text: "Reading" }] } },
-      { type: "tool_call", subtype: "started", call_id: "tool-1", tool_call: { readToolCall: { args: { path: "package.json" } } } },
+      { type: "tool_call", call_id: "tool-1", tool_call: { readToolCall: { args: { path: "package.json" } } } },
       { type: "assistant", timestamp_ms: 3, message: { role: "assistant", content: [{ type: "text", text: "Done" }] } },
       { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Done" }] } },
     ].map((event) => JSON.stringify(event)).join("\n");
@@ -69,6 +69,21 @@ describe("extractCompletionFromStream", () => {
     expect(extractCompletionFromStream(output)).toEqual({
       assistantText: "ReadingDone",
       reasoningText: "",
+    });
+  });
+
+  it("keeps reasoning across an omitted-subtype tool boundary", () => {
+    const output = [
+      { type: "thinking", subtype: "delta", timestamp_ms: 1, text: "Plan" },
+      { type: "thinking", subtype: "delta", timestamp_ms: 2, model_call_id: "call-before-tool", text: "Plan" },
+      { type: "tool_call", call_id: "tool-1", tool_call: { readToolCall: { args: { path: "package.json" } } } },
+      { type: "thinking", subtype: "delta", timestamp_ms: 3, text: "Done" },
+      { type: "thinking", subtype: "completed", text: "Done" },
+    ].map((event) => JSON.stringify(event)).join("\n");
+
+    expect(extractCompletionFromStream(output)).toEqual({
+      assistantText: "",
+      reasoningText: "PlanDone",
     });
   });
 

--- a/tests/unit/plugin-stream-extraction.test.ts
+++ b/tests/unit/plugin-stream-extraction.test.ts
@@ -43,7 +43,36 @@ describe("extractCompletionFromStream", () => {
     });
   });
 
-  it("does not duplicate assistant text when partial events mix delta and accumulated payloads", () => {
+  it("preserves raw assistant tokens that repeat the emitted prefix", () => {
+    const output = [
+      { type: "assistant", timestamp_ms: 1, message: { role: "assistant", content: [{ type: "text", text: "**" }] } },
+      { type: "assistant", timestamp_ms: 2, message: { role: "assistant", content: [{ type: "text", text: "Heading" }] } },
+      { type: "assistant", timestamp_ms: 3, message: { role: "assistant", content: [{ type: "text", text: "**" }] } },
+      { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "**Heading**" }] } },
+    ].map((event) => JSON.stringify(event)).join("\n");
+
+    expect(extractCompletionFromStream(output)).toEqual({
+      assistantText: "**Heading**",
+      reasoningText: "",
+    });
+  });
+
+  it("keeps snapshot tracking within tool-separated assistant segments", () => {
+    const output = [
+      { type: "assistant", timestamp_ms: 1, message: { role: "assistant", content: [{ type: "text", text: "Reading" }] } },
+      { type: "assistant", timestamp_ms: 2, model_call_id: "call-before-tool", message: { role: "assistant", content: [{ type: "text", text: "Reading" }] } },
+      { type: "tool_call", subtype: "started", call_id: "tool-1", tool_call: { readToolCall: { args: { path: "package.json" } } } },
+      { type: "assistant", timestamp_ms: 3, message: { role: "assistant", content: [{ type: "text", text: "Done" }] } },
+      { type: "assistant", message: { role: "assistant", content: [{ type: "text", text: "Done" }] } },
+    ].map((event) => JSON.stringify(event)).join("\n");
+
+    expect(extractCompletionFromStream(output)).toEqual({
+      assistantText: "ReadingDone",
+      reasoningText: "",
+    });
+  });
+
+  it("does not duplicate assistant text when partials include a model-call snapshot", () => {
     const output = [
       JSON.stringify({
         type: "assistant",
@@ -64,6 +93,7 @@ describe("extractCompletionFromStream", () => {
       JSON.stringify({
         type: "assistant",
         timestamp_ms: 3,
+        model_call_id: "model-call-1",
         message: {
           role: "assistant",
           content: [{ type: "text", text: "Hello world!" }],
@@ -103,7 +133,7 @@ describe("extractCompletionFromStream", () => {
     });
   });
 
-  it("does not duplicate thinking text when partial events mix delta and accumulated payloads", () => {
+  it("does not duplicate thinking text when partials include a model-call snapshot", () => {
     const output = [
       JSON.stringify({
         type: "thinking",
@@ -121,6 +151,7 @@ describe("extractCompletionFromStream", () => {
         type: "thinking",
         subtype: "delta",
         timestamp_ms: 3,
+        model_call_id: "model-call-1",
         text: "Plan more carefully",
       }),
     ].join("\n");
@@ -141,6 +172,30 @@ describe("extractCompletionFromStream", () => {
     expect(extractCompletionFromStream(output)).toEqual({
       assistantText: "",
       reasoningText: "Plan more",
+    });
+  });
+
+  it("replaces a corrected accumulated assistant segment", () => {
+    const output = [
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello world" }],
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Hello there" }],
+        },
+      }),
+    ].join("\n");
+
+    expect(extractCompletionFromStream(output)).toEqual({
+      assistantText: "Hello there",
+      reasoningText: "",
     });
   });
 });

--- a/tests/unit/streaming/ai-sdk-parts.test.ts
+++ b/tests/unit/streaming/ai-sdk-parts.test.ts
@@ -146,7 +146,56 @@ describe("ai-sdk stream parts", () => {
     expect(final).toEqual([]);
   });
 
-  it("handles text streams that mix delta and accumulated partial events", () => {
+  it("preserves repeated raw tokens and resets snapshot tracking after tools", () => {
+    const converter = new StreamToAiSdkParts();
+    const parts = [
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 1,
+        message: { role: "assistant", content: [{ type: "text", text: "Reading" }] },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 2,
+        model_call_id: "call-before-tool",
+        message: { role: "assistant", content: [{ type: "text", text: "Reading" }] },
+      }),
+      ...converter.handleEvent({
+        type: "tool_call",
+        subtype: "started",
+        call_id: "tool-1",
+        tool_call: { readToolCall: { args: { path: "package.json" } } },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 3,
+        message: { role: "assistant", content: [{ type: "text", text: "**" }] },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 4,
+        message: { role: "assistant", content: [{ type: "text", text: "Done" }] },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 5,
+        message: { role: "assistant", content: [{ type: "text", text: "**" }] },
+      }),
+    ];
+    const final = converter.handleEvent({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "**Done**" }] },
+    });
+    const text = parts
+      .filter((part) => part.type === "text-delta")
+      .map((part) => part.textDelta)
+      .join("");
+
+    expect(text).toBe("Reading**Done**");
+    expect(final).toEqual([]);
+  });
+
+  it("handles text streams that include a timestamped model-call snapshot", () => {
     const converter = new StreamToAiSdkParts();
     const now = Date.now();
 
@@ -171,6 +220,7 @@ describe("ai-sdk stream parts", () => {
     expect(converter.handleEvent({
       type: "assistant",
       timestamp_ms: now + 3,
+      model_call_id: "model-call-1",
       message: {
         role: "assistant",
         content: [{ type: "text", text: "Hello world!" }],
@@ -216,7 +266,7 @@ describe("ai-sdk stream parts", () => {
     expect(final).toEqual([]);
   });
 
-  it("handles thinking streams that mix delta and accumulated partial events", () => {
+  it("handles thinking streams that include a timestamped model-call snapshot", () => {
     const converter = new StreamToAiSdkParts();
     const now = Date.now();
 
@@ -241,6 +291,7 @@ describe("ai-sdk stream parts", () => {
     expect(converter.handleEvent({
       type: "assistant",
       timestamp_ms: now + 3,
+      model_call_id: "model-call-1",
       message: {
         role: "assistant",
         content: [{ type: "thinking", thinking: "Plan more carefully" }],

--- a/tests/unit/streaming/ai-sdk-parts.test.ts
+++ b/tests/unit/streaming/ai-sdk-parts.test.ts
@@ -162,7 +162,6 @@ describe("ai-sdk stream parts", () => {
       }),
       ...converter.handleEvent({
         type: "tool_call",
-        subtype: "started",
         call_id: "tool-1",
         tool_call: { readToolCall: { args: { path: "package.json" } } },
       }),

--- a/tests/unit/streaming/delta-tracker.test.ts
+++ b/tests/unit/streaming/delta-tracker.test.ts
@@ -90,6 +90,15 @@ describe("DeltaTracker", () => {
 });
 
 describe("MixedDeltaTracker", () => {
+  it("preserves raw deltas that repeat an emitted prefix", () => {
+    const tracker = new MixedDeltaTracker();
+
+    expect(tracker.nextText("**", true)).toBe("**");
+    expect(tracker.nextText("Heading", true)).toBe("Heading");
+    expect(tracker.nextText("**", true)).toBe("**");
+    expect(tracker.nextText("**Heading**")).toBe("");
+  });
+
   it("handles streams that mix delta and accumulated text payloads", () => {
     const tracker = new MixedDeltaTracker();
 
@@ -105,5 +114,14 @@ describe("MixedDeltaTracker", () => {
     expect(tracker.nextThinking(" more")).toBe(" more");
     expect(tracker.nextText("Answer")).toBe("Answer");
     expect(tracker.nextThinking("Plan more carefully")).toBe(" carefully");
+  });
+
+  it("preserves repeated raw thinking deltas", () => {
+    const tracker = new MixedDeltaTracker();
+
+    expect(tracker.nextThinking("**", true)).toBe("**");
+    expect(tracker.nextThinking("Plan", true)).toBe("Plan");
+    expect(tracker.nextThinking("**", true)).toBe("**");
+    expect(tracker.nextThinking("**Plan**")).toBe("");
   });
 });

--- a/tests/unit/streaming/openai-sse.test.ts
+++ b/tests/unit/streaming/openai-sse.test.ts
@@ -148,7 +148,59 @@ describe("openai-sse", () => {
     expect(final).toEqual([]);
   });
 
-  it("handles text streams that mix delta and accumulated partial events", () => {
+  it("preserves repeated raw tokens and resets snapshot tracking after tools", () => {
+    const converter = new StreamToSseConverter("test-model", {
+      id: "chunk-id",
+      created: 123,
+    });
+    const chunks = [
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 1,
+        message: { role: "assistant", content: [{ type: "text", text: "Reading" }] },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 2,
+        model_call_id: "call-before-tool",
+        message: { role: "assistant", content: [{ type: "text", text: "Reading" }] },
+      }),
+      ...converter.handleEvent({
+        type: "tool_call",
+        subtype: "started",
+        call_id: "tool-1",
+        tool_call: { readToolCall: { args: { path: "package.json" } } },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 3,
+        message: { role: "assistant", content: [{ type: "text", text: "**" }] },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 4,
+        message: { role: "assistant", content: [{ type: "text", text: "Done" }] },
+      }),
+      ...converter.handleEvent({
+        type: "assistant",
+        timestamp_ms: 5,
+        message: { role: "assistant", content: [{ type: "text", text: "**" }] },
+      }),
+    ];
+    const final = converter.handleEvent({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "**Done**" }] },
+    });
+    const text = chunks
+      .map(parseChunk)
+      .map((chunk) => chunk.choices[0].delta.content ?? "")
+      .join("");
+
+    expect(text).toBe("Reading**Done**");
+    expect(final).toEqual([]);
+  });
+
+  it("handles text streams that include a timestamped model-call snapshot", () => {
     const converter = new StreamToSseConverter("test-model", {
       id: "chunk-id",
       created: 123,
@@ -174,6 +226,7 @@ describe("openai-sse", () => {
     const third = converter.handleEvent({
       type: "assistant",
       timestamp_ms: now + 3,
+      model_call_id: "model-call-1",
       message: {
         role: "assistant",
         content: [{ type: "text", text: "Hello world!" }],
@@ -229,7 +282,7 @@ describe("openai-sse", () => {
     expect(final).toEqual([]);
   });
 
-  it("handles thinking streams that mix delta and accumulated partial events", () => {
+  it("handles thinking streams that include a timestamped model-call snapshot", () => {
     const converter = new StreamToSseConverter("test-model", {
       id: "chunk-id",
       created: 123,
@@ -255,6 +308,7 @@ describe("openai-sse", () => {
     const third = converter.handleEvent({
       type: "assistant",
       timestamp_ms: now + 3,
+      model_call_id: "model-call-1",
       message: {
         role: "assistant",
         content: [{ type: "thinking", thinking: "Plan more carefully" }],

--- a/tests/unit/streaming/openai-sse.test.ts
+++ b/tests/unit/streaming/openai-sse.test.ts
@@ -167,7 +167,6 @@ describe("openai-sse", () => {
       }),
       ...converter.handleEvent({
         type: "tool_call",
-        subtype: "started",
         call_id: "tool-1",
         tool_call: { readToolCall: { args: { path: "package.json" } } },
       }),


### PR DESCRIPTION
## Summary

- Classify timestamped assistant events without `model_call_id` as raw deltas, preserving repeated tokens such as closing Markdown delimiters.
- Reset stream state at tool starts and assemble non-stream responses by model segment, allowing corrected snapshots to replace earlier text.

## Validation

- `bun run build`
- `bun run test:ci:unit` (532 passed)
- `bun run test:ci:integration` (37 passed, 1 skipped)
- Live Composer 2.5 and Grok 4.5 runs covered repeated delimiters, intentional repeated text, a 241-event answer, and tool boundaries. Reconstructed text matched Cursor's final result in all 13 captured invocations.

## Scope

Cursor emitted `model_call_id` on timestamped accumulated snapshots in each captured run. A protocol change would require a classifier update.

One Grok tool continuation took about 75 seconds and produced no duplicate text. Literal tool-call prose falls outside this change.

Addresses the duplicate-response symptom in #114.
