### PR TITLE
Expose canonical local fallback tools

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2614,6 +2614,13 @@ export function shouldRegisterNativeToolHook(toolName: string, mode: ToolLoopMod
   return !(mode === "opencode" && OPENCODE_NATIVE_TOOL_HOOK_EXCLUSIONS.has(toolName));
 }
 
+export function buildLocalFallbackTools(registry: CoreRegistry): any[] {
+  return registry.list().flatMap((t) => {
+    const ocAlias = `oc_${t.id}`;
+    return t.name === ocAlias ? [t] : [t, { ...t, name: ocAlias }];
+  });
+}
+
 function buildToolHookEntries(registry: CoreRegistry, fallbackBaseDir?: string): Record<string, any> {
   const entries: Record<string, any> = {};
   const sessionWorkspaceBySession = new Map<string, string>();
@@ -2812,7 +2819,7 @@ export const CursorPlugin: Plugin = async ({ $, directory, worktree, client, ser
     };
 
     // Always include local tools — these work regardless of SDK connectivity
-    const localTools = localRegistry.list().map((t) => ({ ...t, name: `oc_${t.id}` }));
+    const localTools = buildLocalFallbackTools(localRegistry);
     for (const asTool of localTools) {
       const nsName = asTool.name;
       add(nsName, asTool);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2614,9 +2614,51 @@ export function shouldRegisterNativeToolHook(toolName: string, mode: ToolLoopMod
   return !(mode === "opencode" && OPENCODE_NATIVE_TOOL_HOOK_EXCLUSIONS.has(toolName));
 }
 
-export function buildLocalFallbackTools(registry: CoreRegistry): any[] {
+// OpenCode-native edit/write use camelCase arg names; the plugin's local registry
+// uses snake_case. Only these keys diverge in case between the two contracts.
+const NATIVE_CANONICAL_KEY_MAP: Record<string, string> = {
+  path: "filePath",
+  old_string: "oldString",
+  new_string: "newString",
+};
+
+/**
+ * Remap a local (snake_case) tool schema to OpenCode's native camelCase contract for
+ * the keys that diverge. Other properties (e.g. cursor-agent compat fields) pass through
+ * unchanged. Returns a new object; the input is not mutated.
+ */
+function toNativeCanonicalSchema(parameters: unknown): unknown {
+  if (!parameters || typeof parameters !== "object") return parameters;
+  const p = parameters as Record<string, any>;
+  const remap = (key: string) => NATIVE_CANONICAL_KEY_MAP[key] ?? key;
+  const properties: Record<string, unknown> = {};
+  if (p.properties && typeof p.properties === "object") {
+    for (const [key, value] of Object.entries(p.properties)) {
+      properties[remap(key)] = value;
+    }
+  }
+  const required = Array.isArray(p.required) ? p.required.map(remap) : p.required;
+  return { ...p, properties, required };
+}
+
+export function buildLocalFallbackTools(
+  registry: CoreRegistry,
+  mode: ToolLoopMode = "opencode",
+): any[] {
+  // In opencode mode, canonical edit/write are executed by OpenCode's NATIVE tools
+  // (camelCase: filePath/oldString/newString), not by the plugin — see
+  // OPENCODE_NATIVE_TOOL_HOOK_EXCLUSIONS. So the canonical fallback entry must advertise
+  // the native camelCase schema; otherwise the schema-compat layer coerces the model's
+  // args to the advertised snake_case and the native handler rejects them. The oc_* alias
+  // keeps the local snake_case schema because it routes to the plugin's own registry.
+  // In proxy-exec mode the plugin executes these locally, so snake_case stays correct.
+  const canonicalIsNative = mode === "opencode";
   return registry.list().flatMap((t) => {
     const ocAlias = `oc_${t.id}`;
+    if (canonicalIsNative && OPENCODE_NATIVE_TOOL_HOOK_EXCLUSIONS.has(t.name)) {
+      const canonical = { ...t, parameters: toNativeCanonicalSchema(t.parameters) };
+      return t.name === ocAlias ? [canonical] : [canonical, { ...t, name: ocAlias }];
+    }
     return t.name === ocAlias ? [t] : [t, { ...t, name: ocAlias }];
   });
 }
@@ -2819,7 +2861,7 @@ export const CursorPlugin: Plugin = async ({ $, directory, worktree, client, ser
     };
 
     // Always include local tools — these work regardless of SDK connectivity
-    const localTools = buildLocalFallbackTools(localRegistry);
+    const localTools = buildLocalFallbackTools(localRegistry, TOOL_LOOP_MODE);
     for (const asTool of localTools) {
       const nsName = asTool.name;
       add(nsName, asTool);

--- a/tests/unit/plugin-tool-resolution.test.ts
+++ b/tests/unit/plugin-tool-resolution.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { applyCursorWriteToolContract, resolveChatParamTools } from "../../src/plugin";
+import {
+  applyCursorWriteToolContract,
+  buildLocalFallbackTools,
+  resolveChatParamTools,
+} from "../../src/plugin";
+import { ToolRegistry as CoreRegistry } from "../../src/tools/core/registry";
+import { registerDefaultTools } from "../../src/tools/defaults";
 
 describe("resolveChatParamTools", () => {
   it("preserves existing tools in opencode mode", () => {
@@ -33,6 +39,20 @@ describe("resolveChatParamTools", () => {
 
     expect(resolved.action).toBe("none");
     expect(resolved.tools).toBe(existing);
+  });
+});
+
+describe("buildLocalFallbackTools", () => {
+  it("exposes local edit and write tools under canonical and oc-prefixed names", () => {
+    const registry = new CoreRegistry();
+    registerDefaultTools(registry);
+
+    const names = buildLocalFallbackTools(registry).map((tool) => tool.name);
+
+    expect(names).toContain("edit");
+    expect(names).toContain("oc_edit");
+    expect(names).toContain("write");
+    expect(names).toContain("oc_write");
   });
 });
 

--- a/tests/unit/plugin-tool-resolution.test.ts
+++ b/tests/unit/plugin-tool-resolution.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../src/plugin";
 import { ToolRegistry as CoreRegistry } from "../../src/tools/core/registry";
 import { registerDefaultTools } from "../../src/tools/defaults";
+import { applyToolSchemaCompat, buildToolSchemaMap } from "../../src/provider/tool-schema-compat";
 
 describe("resolveChatParamTools", () => {
   it("preserves existing tools in opencode mode", () => {
@@ -53,6 +54,85 @@ describe("buildLocalFallbackTools", () => {
     expect(names).toContain("oc_edit");
     expect(names).toContain("write");
     expect(names).toContain("oc_write");
+  });
+
+  it("advertises canonical edit/write with OpenCode-native camelCase schema in opencode mode", () => {
+    const registry = new CoreRegistry();
+    registerDefaultTools(registry);
+
+    const tools = buildLocalFallbackTools(registry, "opencode");
+    const byName = (name: string) => tools.find((t) => t.name === name) as any;
+
+    // Canonical names are executed by OpenCode-native tools (camelCase contract).
+    expect(byName("edit").parameters.required).toEqual(["filePath", "oldString", "newString"]);
+    expect(byName("write").parameters.required).toEqual(["filePath", "content"]);
+
+    // oc_* aliases route to the plugin's local registry, which uses snake_case.
+    expect(byName("oc_edit").parameters.required).toEqual(["path", "old_string", "new_string"]);
+    expect(byName("oc_write").parameters.required).toEqual(["path", "content"]);
+  });
+
+  it("keeps canonical edit/write snake_case in proxy-exec mode (plugin executes locally)", () => {
+    const registry = new CoreRegistry();
+    registerDefaultTools(registry);
+
+    const tools = buildLocalFallbackTools(registry, "proxy-exec");
+    const byName = (name: string) => tools.find((t) => t.name === name) as any;
+
+    expect(byName("edit").parameters.required).toEqual(["path", "old_string", "new_string"]);
+    expect(byName("write").parameters.required).toEqual(["path", "content"]);
+  });
+});
+
+describe("opencode fallback canonical schema round-trips through schema-compat", () => {
+  const nativeSchemaMap = () => {
+    const registry = new CoreRegistry();
+    registerDefaultTools(registry);
+    const tools = buildLocalFallbackTools(registry, "opencode").map((t) => ({
+      type: "function" as const,
+      function: { name: t.name, parameters: t.parameters },
+    }));
+    return buildToolSchemaMap(tools);
+  };
+  const call = (name: string, args: Record<string, unknown>) =>
+    ({ id: "1", type: "function", function: { name, arguments: JSON.stringify(args) } }) as any;
+
+  it("repairs snake_case edit args to camelCase against the native schema", () => {
+    const result = applyToolSchemaCompat(
+      call("edit", { path: "/x", old_string: "a", new_string: "b" }),
+      nativeSchemaMap(),
+    );
+    expect(result.validation.ok).toBe(true);
+    expect(JSON.parse(result.toolCall.function.arguments)).toEqual({
+      filePath: "/x",
+      oldString: "a",
+      newString: "b",
+    });
+  });
+
+  it("repairs snake_case write args to camelCase against the native schema", () => {
+    const result = applyToolSchemaCompat(
+      call("write", { path: "/x", content: "c" }),
+      nativeSchemaMap(),
+    );
+    expect(result.validation.ok).toBe(true);
+    expect(JSON.parse(result.toolCall.function.arguments)).toEqual({
+      filePath: "/x",
+      content: "c",
+    });
+  });
+
+  it("passes camelCase edit args through unchanged against the native schema", () => {
+    const result = applyToolSchemaCompat(
+      call("edit", { filePath: "/x", oldString: "a", newString: "b" }),
+      nativeSchemaMap(),
+    );
+    expect(result.validation.ok).toBe(true);
+    expect(JSON.parse(result.toolCall.function.arguments)).toEqual({
+      filePath: "/x",
+      oldString: "a",
+      newString: "b",
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #116 by including local tools under both their canonical names (for example, \`edit\` and \`write\`) and existing \`oc_*\` aliases when the tool list falls back to locally registered tools.

## Notes

- Keeps existing \`oc_*\` aliases for bridge compatibility.
- Adds a regression test for canonical and prefixed local fallback names.
- Draft for now.

## Testing

- \`bun test tests/unit/plugin-tool-resolution.test.ts\`

Made with [Cursor](https://cursor.com)