### PR TITLE
fix(tools): make edit repair hints match advertised schema names

### DIFF
--- a/src/provider/tool-schema-compat.ts
+++ b/src/provider/tool-schema-compat.ts
@@ -751,6 +751,28 @@ function writeToolExample(writeSchema: unknown): string {
   return "write with path and content";
 }
 
+/**
+ * Infer the edit tool's advertised arg names from schema validation `missing`
+ * keys. OpenCode-native edit uses camelCase (filePath/oldString/newString);
+ * the plugin's local/oc_* registry uses snake_case (path/old_string/new_string).
+ * Repair hints must match the schema the model was given — mixed naming
+ * causes retry loops on Auto/Composer.
+ */
+function editContractArgNames(missing: string[]): {
+  path: string;
+  oldString: string;
+  newString: string;
+} {
+  const usesNativeCamelCase =
+    missing.includes("filePath")
+    || missing.includes("oldString")
+    || missing.includes("newString");
+  if (usesNativeCamelCase) {
+    return { path: "filePath", oldString: "oldString", newString: "newString" };
+  }
+  return { path: "path", oldString: "old_string", newString: "new_string" };
+}
+
 function buildEditFullFileHint(
   args: JsonRecord,
   missing: string[],
@@ -778,7 +800,8 @@ function buildEditFullFileHint(
   }
 
   const example = writeToolExample(context.writeSchema);
-  return `For a full file body, use ${example} instead of edit without old_string`;
+  const { oldString } = editContractArgNames(missing);
+  return `For a full file body, use ${example} instead of edit without ${oldString}`;
 }
 
 function buildRepairHint(
@@ -811,7 +834,8 @@ function buildRepairHint(
     isToolName(toolName, "edit")
     && (missing.includes("old_string") || missing.includes("oldString") || missing.includes("new_string") || missing.includes("newString"))
   ) {
-    hints.push("edit requires path, old_string, and new_string");
+    const keys = editContractArgNames(missing);
+    hints.push(`edit requires ${keys.path}, ${keys.oldString}, and ${keys.newString}`);
   }
 
   return hints.join(" | ");

--- a/tests/unit/provider-tool-schema-compat.test.ts
+++ b/tests/unit/provider-tool-schema-compat.test.ts
@@ -778,6 +778,128 @@ describe("tool schema compatibility", () => {
     expect(result.validation.repairHint).toContain("write");
   });
 
+  describe("edit repair hint naming", () => {
+    it("uses native camelCase contract when edit schema is filePath/oldString/newString", () => {
+      const result = applyToolSchemaCompat(
+        {
+          id: "c_native_edit_hint",
+          type: "function",
+          function: {
+            name: "edit",
+            arguments: JSON.stringify({ filePath: "/tmp/out.txt" }),
+          },
+        },
+        new Map([
+          [
+            "edit",
+            {
+              type: "object",
+              properties: {
+                filePath: { type: "string" },
+                oldString: { type: "string" },
+                newString: { type: "string" },
+              },
+              required: ["filePath", "oldString", "newString"],
+              additionalProperties: false,
+            },
+          ],
+        ]),
+      );
+
+      expect(result.validation.ok).toBe(false);
+      expect(result.validation.missing).toEqual(["oldString", "newString"]);
+      expect(result.validation.repairHint).toBe(
+        "missing required: oldString, newString | edit requires filePath, oldString, and newString",
+      );
+      expect(result.validation.repairHint).not.toContain("old_string");
+      expect(result.validation.repairHint).not.toContain("new_string");
+    });
+
+    it("keeps snake_case contract when edit schema is path/old_string/new_string", () => {
+      const result = applyToolSchemaCompat(
+        {
+          id: "c_local_edit_hint",
+          type: "function",
+          function: {
+            name: "edit",
+            arguments: JSON.stringify({ path: "/tmp/out.txt" }),
+          },
+        },
+        new Map([
+          [
+            "edit",
+            {
+              type: "object",
+              properties: {
+                path: { type: "string" },
+                old_string: { type: "string" },
+                new_string: { type: "string" },
+              },
+              required: ["path", "old_string", "new_string"],
+              additionalProperties: false,
+            },
+          ],
+        ]),
+      );
+
+      expect(result.validation.ok).toBe(false);
+      expect(result.validation.missing).toEqual(["old_string", "new_string"]);
+      expect(result.validation.repairHint).toBe(
+        "missing required: old_string, new_string | edit requires path, old_string, and new_string",
+      );
+      expect(result.validation.repairHint).not.toContain("oldString");
+      expect(result.validation.repairHint).not.toContain("filePath");
+    });
+
+    it("full-file hint names the missing old* key from the edit schema", () => {
+      const result = applyToolSchemaCompat(
+        {
+          id: "c_native_full_file_hint",
+          type: "function",
+          function: {
+            name: "edit",
+            arguments: JSON.stringify({
+              filePath: "/tmp/out.txt",
+              content: "entire body",
+            }),
+          },
+        },
+        new Map([
+          [
+            "edit",
+            {
+              type: "object",
+              properties: {
+                filePath: { type: "string" },
+                oldString: { type: "string" },
+                newString: { type: "string" },
+              },
+              required: ["filePath", "oldString", "newString"],
+              additionalProperties: false,
+            },
+          ],
+          [
+            "write",
+            {
+              type: "object",
+              properties: {
+                filePath: { type: "string" },
+                content: { type: "string" },
+              },
+              required: ["filePath", "content"],
+            },
+          ],
+        ]),
+      );
+
+      expect(result.validation.ok).toBe(false);
+      expect(result.validation.missing).toEqual(["oldString"]);
+      expect(result.validation.repairHint).toContain("write with filePath and content");
+      expect(result.validation.repairHint).toContain("without oldString");
+      expect(result.validation.repairHint).not.toContain("without old_string");
+    });
+  });
+
   describe("edit to write reroute", () => {
     it("full-file hint uses filePath when write schema requires filePath", () => {
       const toolSchemaMap = buildEditWriteSchemaMap(true);


### PR DESCRIPTION
## Summary
- OpenCode-native `edit` advertises camelCase args (`filePath` / `oldString` / `newString`), but schema-validation repair hints always said `path` / `old_string` / `new_string`.
- That mismatch showed up as messages like `missing required: oldString, newString | edit requires path, old_string, and new_string`, which steered models into retrying with the wrong names until the loop guard blocked `edit`.
- Derive the “edit requires …” contract (and the full-file “without old*” phrasing) from the schema’s missing keys so hints match what was advertised. Local/snake_case schemas are unchanged.

## Test plan
- [x] `bun test --isolate tests/unit/provider-tool-schema-compat.test.ts`
- [x] `bun test --isolate tests/unit/provider-tool-schema-compat.test.ts tests/unit/provider-runtime-interception.test.ts tests/unit/plugin-tool-resolution.test.ts` (93 pass)
- [ ] Reproduce malformed native `edit` (missing old/new strings) and confirm the hint says `filePath, oldString, and newString` with no snake_case mix