### PR TITLE
fix(tools): map cursor-agent subagentType to canonical subagent_type

### DIFF
--- a/src/provider/tool-schema-compat.ts
+++ b/src/provider/tool-schema-compat.ts
@@ -41,6 +41,18 @@ const ARG_KEY_ALIASES = new Map<string, string>([
   ["recursive", "force"],
   ["oldstring", "old_string"],
   ["newstring", "new_string"],
+  ["subagenttype", "subagent_type"],
+]);
+
+// cursor-agent names its own subagent roster (see `mapSubagentType` in the
+// cursor-agent client bundle: computer_use, explore, video_review, browser_use,
+// shell, vm_setup_helper, unspecified, or a `{ custom: <name> }` wrapper).
+// Only the entries below have an unambiguous OpenCode counterpart; every other
+// value is forwarded untouched so OpenCode can answer with its own
+// "Agent not found: X. Available agents: ..." message instead of a schema error.
+const CURSOR_SUBAGENT_TYPE_ALIASES = new Map<string, string>([
+  ["unspecified", "general"],
+  ["generalpurpose", "general"],
 ]);
 
 export interface ToolSchemaValidationResult {
@@ -291,10 +303,45 @@ function resolveCanonicalArgKey(rawKey: string): string | null {
   return ARG_KEY_ALIASES.get(token) ?? null;
 }
 
+function resolveCursorSubagentType(value: unknown): string | null {
+  let raw: string | null = null;
+
+  if (typeof value === "string") {
+    raw = value;
+  } else if (isRecord(value)) {
+    // cursor-agent encodes its subagent selection as a single-key wrapper:
+    // `{ custom: "reviewer" }` carries the name in the value, while oneof
+    // markers such as `{ unspecified: {} }` carry it in the key.
+    const keys = Object.keys(value);
+    if (keys.length !== 1) {
+      return null;
+    }
+    const [key] = keys;
+    const inner = value[key];
+    raw = typeof inner === "string" && inner.trim().length > 0 ? inner : key;
+  }
+
+  if (raw === null || raw.trim().length === 0) {
+    return null;
+  }
+
+  const trimmed = raw.trim();
+  const token = trimmed.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return CURSOR_SUBAGENT_TYPE_ALIASES.get(token) ?? trimmed;
+}
+
 function normalizeToolSpecificArgs(toolName: string, args: JsonRecord, schema?: unknown): JsonRecord {
   const normalizedToolName = toolName.toLowerCase();
   if (normalizedToolName === "question" && QUESTION_COMPAT_REPAIR_ENABLED) {
     return normalizeQuestionArgs(args);
+  }
+
+  if (normalizedToolName === "task") {
+    const subagentType = resolveCursorSubagentType(args.subagent_type);
+    if (subagentType === null || subagentType === args.subagent_type) {
+      return args;
+    }
+    return { ...args, subagent_type: subagentType };
   }
 
   if (normalizedToolName === "bash") {

--- a/tests/unit/provider-tool-schema-compat.test.ts
+++ b/tests/unit/provider-tool-schema-compat.test.ts
@@ -778,6 +778,144 @@ describe("tool schema compatibility", () => {
     expect(result.validation.repairHint).toContain("write");
   });
 
+  describe("cursor task subagent type", () => {
+    function buildTaskCall(args: Record<string, unknown>): OpenAiToolCall {
+      return {
+        id: "c_task",
+        type: "function",
+        function: { name: "task", arguments: JSON.stringify(args) },
+      };
+    }
+
+    function buildTaskSchemaMap(): Map<string, unknown> {
+      return new Map([
+        [
+          "task",
+          {
+            type: "object",
+            properties: {
+              description: { type: "string" },
+              prompt: { type: "string" },
+              subagent_type: { type: "string" },
+            },
+            required: ["description", "prompt", "subagent_type"],
+            additionalProperties: false,
+          },
+        ],
+      ]);
+    }
+
+    it("normalizes cursor-agent subagentType to canonical subagent_type", () => {
+      const result = applyToolSchemaCompat(
+        buildTaskCall({
+          description: "review plan",
+          prompt: "review the plan",
+          subagentType: "explore",
+        }),
+        buildTaskSchemaMap(),
+      );
+
+      expect(result.normalizedArgs.subagent_type).toBe("explore");
+      expect(result.normalizedArgs.subagentType).toBeUndefined();
+      expect(result.validation.ok).toBe(true);
+    });
+
+    it("unwraps oneof-style subagentType objects to a string", () => {
+      const result = applyToolSchemaCompat(
+        buildTaskCall({
+          description: "review plan",
+          prompt: "review the plan",
+          subagentType: { unspecified: {} },
+        }),
+        buildTaskSchemaMap(),
+      );
+
+      expect(result.normalizedArgs.subagent_type).toBe("general");
+      expect(result.validation.ok).toBe(true);
+    });
+
+    it("maps the unspecified cursor subagent type to general", () => {
+      const result = applyToolSchemaCompat(
+        buildTaskCall({
+          description: "review plan",
+          prompt: "review the plan",
+          subagentType: "unspecified",
+        }),
+        buildTaskSchemaMap(),
+      );
+
+      expect(result.normalizedArgs.subagent_type).toBe("general");
+      expect(result.validation.ok).toBe(true);
+    });
+
+    it("unwraps a custom cursor subagent wrapper to the custom name", () => {
+      const result = applyToolSchemaCompat(
+        buildTaskCall({
+          description: "review plan",
+          prompt: "review the plan",
+          subagentType: { custom: "homeassistant" },
+        }),
+        buildTaskSchemaMap(),
+      );
+
+      expect(result.normalizedArgs.subagent_type).toBe("homeassistant");
+      expect(result.validation.ok).toBe(true);
+    });
+
+    it("passes through cursor-only subagent types so opencode can name valid agents", () => {
+      const result = applyToolSchemaCompat(
+        buildTaskCall({
+          description: "run shell",
+          prompt: "run it",
+          subagentType: "shell",
+        }),
+        buildTaskSchemaMap(),
+      );
+
+      expect(result.normalizedArgs.subagent_type).toBe("shell");
+      expect(result.validation.ok).toBe(true);
+    });
+
+    it("leaves an already-canonical subagent_type untouched", () => {
+      const result = applyToolSchemaCompat(
+        buildTaskCall({
+          description: "review plan",
+          prompt: "review the plan",
+          subagent_type: "general",
+        }),
+        buildTaskSchemaMap(),
+      );
+
+      expect(result.normalizedArgs.subagent_type).toBe("general");
+      expect(result.validation.ok).toBe(true);
+    });
+
+    it("drops cursor-only task arguments the opencode schema does not declare", () => {
+      const result = applyToolSchemaCompat(
+        buildTaskCall({
+          description: "review plan",
+          prompt: "review the plan",
+          subagentType: { unspecified: {} },
+          agentId: "agent_123",
+          attachments: [],
+          mode: "default",
+          environment: "local",
+          respondingToMessageIds: ["m1"],
+        }),
+        buildTaskSchemaMap(),
+      );
+
+      const args = JSON.parse(result.toolCall.function.arguments);
+      expect(args.subagent_type).toBe("general");
+      expect(args.agentId).toBeUndefined();
+      expect(args.attachments).toBeUndefined();
+      expect(args.mode).toBeUndefined();
+      expect(args.environment).toBeUndefined();
+      expect(args.respondingToMessageIds).toBeUndefined();
+      expect(result.validation.ok).toBe(true);
+    });
+  });
+
   describe("edit to write reroute", () => {
     it("full-file hint uses filePath when write schema requires filePath", () => {
       const toolSchemaMap = buildEditWriteSchemaMap(true);


### PR DESCRIPTION
## Summary

Under a Cursor-hosted model, every OpenCode `task` call can fail schema validation:

```
The task tool was called with invalid arguments: SchemaError(Missing key at ["subagent_type"]).
Please rewrite the input so it satisfies the expected schema.
```

The model emits the Cursor `Task` envelope instead of the OpenCode one. Two things differ, and `ARG_KEY_ALIASES` covered neither:

| | Cursor `Task` | OpenCode `task` |
| -- | -- | -- |
| key | `subagentType` | `subagent_type` |
| value | `"explore"`, or a single-key wrapper such as `{ "unspecified": {} }` / `{ "custom": "reviewer" }` | plain string |

Because the key never normalized, `sanitizeArgumentsForSchema` dropped it as an unexpected property and validation reported `subagent_type` missing. Retrying re-emits the same envelope, so the call never converges.

This adds:

- `["subagenttype", "subagent_type"]` to `ARG_KEY_ALIASES`. Key normalization (lowercase + strip non-alphanumerics) means the one entry covers `subagentType`, `subagent_type`, and `subagenttype`.
- A `task` branch in `normalizeToolSpecificArgs` that resolves the value to a string: `{ custom: "reviewer" }` carries the name in the value, while oneof markers such as `{ unspecified: {} }` carry it in the key.
- Aliases for the two values with an unambiguous OpenCode counterpart: `unspecified` and `generalPurpose` map to `general`.

Cursor-only agent types (`computer_use`, `browser_use`, `shell`, `vm_setup_helper`, `video_review`) are deliberately **not** mapped. They are forwarded untouched so OpenCode answers with its own `Agent not found: "shell". Available agents: ...`, which names the valid set and lets the model self-correct. Silently rewriting them to `general` would dispatch the wrong agent with no signal.

Cursor-only extras (`agentId`, `attachments`, `mode`, `environment`, `respondingToMessageIds`) already fall out via `sanitizeArgumentsForSchema`; a test pins that.

## How it was found

Reading the cursor-agent client bundle (`2026.08.04-aaa8809`), whose `mapSubagentType` enumerates the vocabulary:

```js
mapSubagentType(e){switch(e){
  case"computer_use":return"computer_use";
  case"explore":return"explore";
  case"video_review":case"media_review":return"video_review";
  case"browser_use":return"browser_use";
  case"shell":return"shell";
  case"vm_setup_helper":return"vm_setup_helper";
  case void 0:case"unspecified":return"unspecified";
  default:return{custom:e}}}
```

That `default` branch is where the object-shaped values come from, which is why resolving the value has to handle both the wrapper and the bare string.

Prior art: #60 (closed as a duplicate of #51) is the same report. It was addressed prompt-side via `TASK_BRIDGE_JSON_CONTEXT` plus a higher loop-guard threshold. That guidance only binds when the model chooses the bridge-JSON envelope; when it emits a native Cursor `Task` tool call instead, nothing normalized the arguments. This closes that path. Reproduced on 2.5.4 / `main` @ 013ff8e.

## Test

- 7 new cases in `tests/unit/provider-tool-schema-compat.test.ts` covering: key alias, oneof unwrap, `unspecified` to `general`, `{custom:...}` unwrap, cursor-only pass-through, an already-canonical value left untouched, and extras being dropped.
- `bun test tests/unit/provider-tool-schema-compat.test.ts`: **46 pass / 0 fail** (39 before).
- `bun run test:ci:unit`: **572 pass / 5 fail**. The failures are in `tests/unit/proxy/plugin-resume.test.ts`, reproduce on clean `main` (baseline 564 pass / 6 fail), and are flaky across repeat runs (3 / 6 / 5 failing). Unrelated to this change.
