### PR TITLE
fix: preserve v2 proxy routing

### DIFF
--- a/src/plugin-v2.ts
+++ b/src/plugin-v2.ts
@@ -47,6 +47,17 @@ type V2ToolDefinition = {
   execute: (args: any, ctx: any) => Promise<unknown>;
   options: { codemode: true };
 };
+type V2SessionHook = {
+  (name: "context", callback: (event: {
+    model?: { providerID?: string };
+    system: Array<{ type: "text"; text: string }>;
+    tools: Record<string, { description: string; input: Record<string, unknown> }>;
+  }) => Promise<void>): Promise<V2Registration>;
+  (name: "http.request", callback: (event: {
+    model: { providerID: string };
+    request: Request;
+  }) => Promise<void>): Promise<V2Registration>;
+};
 type V2Context = {
   catalog: {
     transform: (callback: (draft: {
@@ -74,13 +85,17 @@ type V2Context = {
     }) => void) => Promise<V2Registration>;
   };
   session: {
-    hook: (name: "context", callback: (event: {
-      model?: { providerID?: string };
-      system: Array<{ type: "text"; text: string }>;
-      tools: Record<string, { description: string; input: Record<string, unknown> }>;
-    }) => Promise<void>) => Promise<V2Registration>;
+    hook: V2SessionHook;
   };
 };
+
+function routeRequestToProxy(request: Request, baseURL: string): Request {
+  const target = new URL(request.url);
+  const proxy = new URL(baseURL);
+  target.protocol = proxy.protocol;
+  target.host = proxy.host;
+  return new Request(target, request);
+}
 
 /** Convert a V1-style tool entry (with zod args) into a V2 tool definition. */
 function v2ToolFromV1(
@@ -194,6 +209,13 @@ export function createV2Setup() {
 
     const proxyBaseURL = await ensureCursorProxyServer(workspaceDirectory, router ?? undefined);
     log.debug("Proxy server started", { baseURL: proxyBaseURL });
+
+    // Config providers load after package plugins in V2 and can overwrite the
+    // catalog URL. Route at the HTTP boundary as the final source of truth.
+    registrations.push(await ctx.session.hook("http.request", async (event) => {
+      if (event.model.providerID !== CURSOR_PROVIDER_ID) return;
+      event.request = routeRequestToProxy(event.request, proxyBaseURL);
+    }));
 
     // Register the cursor-acp provider + auth via catalog/integration transforms.
     registrations.push(await ctx.catalog.transform((catalog) => {

--- a/tests/unit/plugin-v2.test.ts
+++ b/tests/unit/plugin-v2.test.ts
@@ -32,6 +32,7 @@ function registration(onDispose: () => void = () => {}): Registration {
 function createContext() {
   const disposed: string[] = [];
   const toolAddCalls: any[][] = [];
+  let httpRequestHook: ((event: any) => Promise<void>) | undefined;
   let sessionContextHook: ((event: any) => Promise<void>) | undefined;
   let activeConnectionCalls = 0;
   let credential: any = { type: "key", key: "cursor-key" };
@@ -77,9 +78,10 @@ function createContext() {
     },
     session: {
       hook: async (name: string, callback: (event: any) => Promise<void>) => {
-        expect(name).toBe("context");
-        sessionContextHook = callback;
-        return registration(() => disposed.push("session"));
+        if (name === "context") sessionContextHook = callback;
+        else if (name === "http.request") httpRequestHook = callback;
+        else throw new Error(`Unexpected session hook: ${name}`);
+        return registration(() => disposed.push(`session:${name}`));
       },
     },
   };
@@ -91,6 +93,7 @@ function createContext() {
     toolAddCalls,
     activeConnectionCalls: () => activeConnectionCalls,
     setCredential: (value: any) => { credential = value; },
+    httpRequestHook: () => httpRequestHook,
     sessionContextHook: () => sessionContextHook,
   };
 }
@@ -114,6 +117,24 @@ describe("opencode V2 adapter", () => {
     expect(provider.settings.baseURL).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1$/);
     expect(provider.settings.baseURL).not.toBe("http://127.0.0.1:9/v1");
     expect(provider.api).toBeUndefined();
+  });
+
+  test("routes Cursor HTTP requests to the live proxy after config overlays", async () => {
+    const fixture = createContext();
+    await createV2Setup()(fixture.context);
+    const event = {
+      model: { providerID: "cursor-acp" },
+      request: new Request("http://127.0.0.1:9/v1/chat/completions", {
+        method: "POST",
+        body: "probe",
+      }),
+    };
+
+    await fixture.httpRequestHook()!(event);
+
+    expect(event.request.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/v1\/chat\/completions$/);
+    expect(event.request.url).not.toContain(":9/");
+    expect(await event.request.text()).toBe("probe");
   });
 
   test("registers complete tools with one V2 add argument", async () => {
@@ -186,6 +207,8 @@ describe("opencode V2 adapter", () => {
 
     expect(cleanup).toBeTypeOf("function");
     await cleanup!();
-    expect(fixture.disposed.sort()).toEqual(["catalog", "integration", "session", "tool"]);
+    expect(fixture.disposed.sort()).toEqual([
+      "catalog", "integration", "session:context", "session:http.request", "tool",
+    ]);
   });
 });


### PR DESCRIPTION
Fixes the startup-order failure found during the bare-metal V2 test.

opencode applies its config-provider transform after package plugins, which can replace the live proxy URL with a stale configured URL. This routes `cursor-acp` requests through the V2 `session.http.request` hook, while preserving the request path, method, headers, and body.

Checks:
- build
- unit: 592 pass, 0 fail
- integration: 43 pass, 1 skip, 0 fail
- npm pack --dry-run
- bare-metal opencode V2 run with the default proxy port occupied: exit 0, read tool completed, `BAREMETAL_OK` returned