### PR TITLE
fix: refresh models through cli login

### DIFF
--- a/src/models/sync.ts
+++ b/src/models/sync.ts
@@ -11,8 +11,9 @@ import {
   readFileSync as nodeReadFileSync,
   writeFileSync as nodeWriteFileSync,
 } from "node:fs";
-import { listModelsViaRunner } from "../client/sdk-child.js";
 import { resolveSdkApiKey } from "../auth.js";
+import { listModelsViaRunner } from "../client/sdk-child.js";
+import { discoverModelsFromCursorAgent } from "../cli/model-discovery.js";
 import { resolveOpenCodeConfigPath } from "../plugin-toggle.js";
 import { createLogger, type Logger } from "../utils/logger.js";
 import { mergeCursorModelEntries } from "./variants.js";
@@ -25,12 +26,32 @@ type ModelConfigEntry = { name: string };
 type ProviderConfig = { models?: Record<string, unknown> } & Record<string, unknown>;
 type OpenCodeConfig = {
   provider?: Record<string, ProviderConfig | undefined>;
+  providers?: Record<string, ProviderConfig | undefined>;
 } & Record<string, unknown>;
 
 export type DiscoveredModel = {
   id: string;
   name: string;
 };
+
+export async function discoverModelsForRefresh(
+  deps: {
+    discoverFromCursorAgent?: () => DiscoveredModel[];
+    resolveApiKey?: () => string | undefined;
+    discoverViaSdk?: (apiKey: string) => Promise<DiscoveredModel[]>;
+  } = {},
+): Promise<DiscoveredModel[]> {
+  try {
+    return (deps.discoverFromCursorAgent ?? discoverModelsFromCursorAgent)();
+  } catch (agentError) {
+    const apiKey = (deps.resolveApiKey ?? (() => resolveSdkApiKey({ env: process.env })))();
+    if (!apiKey) throw agentError;
+
+    if (deps.discoverViaSdk) return deps.discoverViaSdk(apiKey);
+    const models = await listModelsViaRunner(apiKey);
+    return models.map((model) => ({ id: model.id, name: model.name }));
+  }
+}
 
 type AutoRefreshModelsDeps = {
   defer: () => Promise<void>;
@@ -44,14 +65,7 @@ type AutoRefreshModelsDeps = {
 
 const defaultDeps: AutoRefreshModelsDeps = {
   defer: () => Promise.resolve(),
-  discoverModels: async () => {
-    const apiKey = resolveSdkApiKey({ env: process.env });
-    if (!apiKey) {
-      throw new Error("CURSOR_API_KEY not set");
-    }
-    const models = await listModelsViaRunner(apiKey);
-    return models.map((m) => ({ id: m.id, name: m.name }));
-  },
+  discoverModels: discoverModelsForRefresh,
   env: process.env,
   existsSync: nodeExistsSync,
   log,
@@ -73,12 +87,12 @@ function parseConfig(raw: string): OpenCodeConfig | null {
 }
 
 function getProviderConfig(config: OpenCodeConfig): ProviderConfig | null {
-  if (!isRecord(config.provider)) {
-    return null;
+  for (const providers of [config.providers, config.provider]) {
+    if (!isRecord(providers)) continue;
+    const provider = providers[PROVIDER_ID];
+    if (isRecord(provider)) return provider as ProviderConfig;
   }
-
-  const provider = config.provider[PROVIDER_ID];
-  return isRecord(provider) ? (provider as ProviderConfig) : null;
+  return null;
 }
 
 function getExistingModels(provider: ProviderConfig): Record<string, unknown> {

--- a/tests/unit/models/sync.test.ts
+++ b/tests/unit/models/sync.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "bun:test";
-import { autoRefreshModels } from "../../../src/models/sync.js";
+import {
+  autoRefreshModels,
+  discoverModelsForRefresh,
+} from "../../../src/models/sync.js";
 
 type MockDeps = Parameters<typeof autoRefreshModels>[0];
 
@@ -41,6 +44,60 @@ function createDeps(overrides: MockDeps = {}) {
 describe("models/sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("discovers startup models through cursor-agent without resolving an SDK key", async () => {
+    const resolveApiKey = vi.fn(() => undefined);
+    const discoverViaSdk = vi.fn();
+
+    const models = await discoverModelsForRefresh({
+      discoverFromCursorAgent: () => [
+        { id: "cursor-grok-4.6-high", name: "Cursor Grok 4.6" },
+      ],
+      resolveApiKey,
+      discoverViaSdk,
+    });
+
+    expect(models).toEqual([
+      { id: "cursor-grok-4.6-high", name: "Cursor Grok 4.6" },
+    ]);
+    expect(resolveApiKey).not.toHaveBeenCalled();
+    expect(discoverViaSdk).not.toHaveBeenCalled();
+  });
+
+  it("falls back to SDK discovery when cursor-agent fails and a real key exists", async () => {
+    const agentError = new Error("cursor-agent unavailable");
+    const discoverViaSdk = vi.fn(async () => [
+      { id: "gpt-5.6-sol-high", name: "GPT-5.6 Sol High" },
+    ]);
+
+    const models = await discoverModelsForRefresh({
+      discoverFromCursorAgent: () => {
+        throw agentError;
+      },
+      resolveApiKey: () => "real-key",
+      discoverViaSdk,
+    });
+
+    expect(models).toEqual([
+      { id: "gpt-5.6-sol-high", name: "GPT-5.6 Sol High" },
+    ]);
+    expect(discoverViaSdk).toHaveBeenCalledWith("real-key");
+  });
+
+  it("does not query the SDK or return static models when no live auth path works", async () => {
+    const agentError = new Error("cursor-agent unavailable");
+    const discoverViaSdk = vi.fn();
+
+    await expect(discoverModelsForRefresh({
+      discoverFromCursorAgent: () => {
+        throw agentError;
+      },
+      resolveApiKey: () => undefined,
+      discoverViaSdk,
+    })).rejects.toBe(agentError);
+
+    expect(discoverViaSdk).not.toHaveBeenCalled();
   });
 
   it("adds newly discovered models without removing existing entries", async () => {
@@ -112,6 +169,36 @@ describe("models/sync", () => {
       "custom-model": { name: "Custom" },
       "gpt-5.4-high": { name: "GPT-5.4 High" },
     });
+  });
+
+  it("adds discovered models to the V2 providers config", async () => {
+    const { deps, writeFileSync } = createDeps({
+      readFileSync: vi.fn(() =>
+        JSON.stringify({
+          providers: {
+            "cursor-acp": {
+              models: {
+                auto: { name: "Auto" },
+              },
+            },
+          },
+        }),
+      ),
+      discoverModels: vi.fn(async () => [
+        { id: "auto", name: "Auto" },
+        { id: "cursor-grok-4.6-high", name: "Cursor Grok 4.6" },
+      ]),
+    });
+
+    await autoRefreshModels(deps);
+
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const [, writtenConfig] = writeFileSync.mock.calls[0];
+    const parsed = JSON.parse(writtenConfig as string);
+    expect(parsed.providers["cursor-acp"].models["cursor-grok-4.6-high"]).toEqual({
+      name: "Cursor Grok 4.6",
+    });
+    expect(parsed.provider).toBeUndefined();
   });
 
   it("can disable startup model refresh", async () => {


### PR DESCRIPTION
## summary

- discover startup models through cursor-agent before sdk fallback
- update both v1 `provider` and v2 `providers` configs

## verification

- 592 unit tests pass
- 43 integration tests pass, 1 skipped
- exact opencode v2 refreshed 204 live models without `CURSOR_API_KEY`
- bare-metal `cursor-grok-4.6-high` returned `GROK46_REFRESH_OK`
- build and package dry-run pass
